### PR TITLE
Updated install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Installing Klippain should not be too complicated if you are already familiar wi
 
 Then, to run the installation script, connect to your printer using SSH and type the following command:
 ```
-wget -O - https://raw.githubusercontent.com/Frix-x/klippain/main/install.sh | bash
+wget -O - https://raw.githubusercontent.com/W141-ID/klippain/main/install.sh | bash
 ```
   
 This script will backup your old configuration, download this GitHub repository into your RaspberryPi home directory and setup the entire environment in `~/printer_data/config`. You'll also be asked if you want to select and install some MCU board_pins templates. This is recommended as it will allow a very fast filling of your `mcu.cfg` user file, but you can always do it manually afterwards if you prefer.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Installing Klippain should not be too complicated if you are already familiar wi
 
 Then, to run the installation script, connect to your printer using SSH and type the following command:
 ```
-wget -O - https://raw.githubusercontent.com/W141-ID/klippain/main/install.sh | bash
+wget -O - https://raw.githubusercontent.com/Frix-x/klippain/main/install.sh | bash
 ```
   
 This script will backup your old configuration, download this GitHub repository into your RaspberryPi home directory and setup the entire environment in `~/printer_data/config`. You'll also be asked if you want to select and install some MCU board_pins templates. This is recommended as it will allow a very fast filling of your `mcu.cfg` user file, but you can always do it manually afterwards if you prefer.

--- a/install.sh
+++ b/install.sh
@@ -25,21 +25,6 @@ BACKUP_PATH="${HOME}/klippain_config_backups"
 set -eu
 export LC_ALL=C
 
-# Step 1: Verify that the script is not run as root and Klipper is installed
-function preflight_checks {
-    if [ "$EUID" -eq 0 ]; then
-        echo "[PRE-CHECK] This script must not be run as root!"
-        exit -1
-    fi
-
-    if [ "$(sudo systemctl list-units --full -all -t service --no-legend | grep -F 'klipper.service')" ]; then
-        printf "[PRE-CHECK] Klipper service found! Continuing...\n\n"
-    else
-        echo "[ERROR] Klipper service not found, please install Klipper first!"
-        exit -1
-    fi
-}
-
 function custom_printer_name {
 
     read < /dev/tty -rp "[CONFIG] Would you like to select custom folder locations? (Y/n) " custom_folder
@@ -56,6 +41,21 @@ function custom_printer_name {
     # Input folder name 
     read < /dev/tty -rp "[CONFIG]  Please input the custom Folder name:" USER_CONFIG_PATH_INPUT
         USER_CONFIG_PATH="${HOME}/${USER_CONFIG_PATH_INPUT}/config"
+}
+
+# Step 1: Verify that the script is not run as root and Klipper is installed
+function preflight_checks {
+    if [ "$EUID" -eq 0 ]; then
+        echo "[PRE-CHECK] This script must not be run as root!"
+        exit -1
+    fi
+
+    if [ "$(sudo systemctl list-units --full -all -t service --no-legend | grep -F "${USER_CONFIG_PATH_INPUT}"'-klipper.service')" ]; then
+        printf "[PRE-CHECK] Klipper service found! Continuing...\n\n"
+    else
+        echo "[ERROR] Klipper service not found, please install Klipper first!"
+        exit -1
+    fi
 }
 
 # Step 2: Check if the git config folder exist (or download it)

--- a/install.sh
+++ b/install.sh
@@ -26,8 +26,6 @@ set -eu
 export LC_ALL=C
 
 function folder_name {
-    echo "Please do something"
-
 
     read < /dev/tty -rp "[CONFIG] Would you like to select custom folder locations? (Y/n) " custom_folder
     if [[ -z "$custom_folder" ]]; then

--- a/install.sh
+++ b/install.sh
@@ -40,6 +40,23 @@ function preflight_checks {
     fi
 }
 
+function custom_printer_name {
+
+    read < /dev/tty -rp "[CONFIG] Would you like to select custom folder locations? (Y/n) " custom_folder
+    if [[ -z "$custom_folder" ]]; then
+        custom_folder="y"
+    fi
+
+    # Continue with the standard folder location
+    if [[ "$custom_folder" =~ ^(no|n)$ ]]; then
+        printf "[CONFIG] Using the standard folder configuration!\n\n"
+        return
+    fi
+
+    # Input folder name 
+    read < /dev/tty -rp "[CONFIG]  Please input the custom Folder name:" USER_CONFIG_PATH_INPUT
+        USER_CONFIG_PATH="${HOME}/${USER_CONFIG_PATH_INPUT}/config"
+}
 
 # Step 2: Check if the git config folder exist (or download it)
 function check_download {
@@ -220,7 +237,7 @@ preflight_checks
 check_download
 backup_config
 install_config
-restart_klipper
+restart_"${USER_CONFIG_PATH_INPUT}"-klipper
 
 echo "[POST-INSTALL] Everything is ok, Klippain installed and up to date!"
 echo "[POST-INSTALL] Be sure to check the breaking changes on the release page: https://github.com/Frix-x/klippain/releases"


### PR DESCRIPTION
As I am using one PC for multiple Klipper instances, it was "difficult" to install the config without having a few problems.

By adding the function, the user can choose a custom folder name.
He can always decline if he has only one instance and needs to go the standard route.

I used the following scheme for naming as kiauh does the same:
Services as moonraker & klipper: klipper-xyz
config-data: xyz_data

I can change the function to ask to put in the full folder name.
I hope this addition is helpful to you.

I have tested it on my machine and it worked so far.