### PR TITLE
changed value of max_temp from 70 to 95 for RPiFan

### DIFF
--- a/config/hardware/fans/rpi_fan.cfg
+++ b/config/hardware/fans/rpi_fan.cfg
@@ -4,6 +4,6 @@ kick_start_time: 0.5
 max_speed: 0.75
 target_temp: 50
 min_temp: 10
-max_temp: 70
+max_temp: 95
 control: watermark
 sensor_type: temperature_host


### PR DESCRIPTION
change max temp of RPiFan as the Pi is selfthrotteling and 70 degrees create unnecessary print failures.