### PR TITLE
added zhop when not homing Z to prevent possible scratching after error while z probing (e.g. tap)

### DIFF
--- a/macros/base/homing/homing_overide.cfg
+++ b/macros/base/homing/homing_overide.cfg
@@ -78,6 +78,13 @@ gcode:
 
     G90
 
+    {% if (printer.toolhead.position.z < homing_zhop) %}
+        {% if verbose %}
+            { action_respond_info("Z too low, performing ZHOP") }
+        {% endif %}
+        G0 Z{homing_zhop} F{z_drop_speed}
+    {% endif %}
+
     {% if Z %}
         {% if ('z' in printer.toolhead.homed_axes) %}
             {% if (printer.toolhead.position.z < homing_zhop) %}

--- a/macros/base/homing/homing_overide.cfg
+++ b/macros/base/homing/homing_overide.cfg
@@ -20,8 +20,6 @@ gcode:
     {% set y_position_endstop = printer["configfile"].config["stepper_y"]["position_endstop"]|float %}
     {% set x_position_center = printer.toolhead.axis_maximum.x|int/2 - printer.toolhead.axis_minimum.x|int/2 %}
     {% set y_position_center = printer.toolhead.axis_maximum.y|int/2 - printer.toolhead.axis_minimum.y|int/2 %}
-    
-    {% set homing_force_zhop = printer["gcode_macro _USER_VARIABLES"].homing_force_zhop %}
 
 
     {% if probe_type_enabled == "dockable" %}
@@ -97,20 +95,11 @@ gcode:
             {% set X, Y, Z = True, True, True %}
         {% endif %}
     {% else %}
-        {% if ('z' in printer.toolhead.homed_axes) %}
-            {% if (printer.toolhead.position.z < homing_zhop) %}
-                {% if verbose %}
-                    { action_respond_info("Z too low, performing ZHOP") }
-                {% endif %}
-                G0 Z{homing_zhop} F{z_drop_speed}
-            {% endif %}
-        {% elif homing_force_zhop}
+        {% if (printer.toolhead.position.z < homing_zhop) %}
             {% if verbose %}
-                { action_respond_info("Forcing z hop without homing z.") }
+                { action_respond_info("Z too low, performing ZHOP") }
             {% endif %}
-            SET_KINEMATIC_POSITION X=0 Y=0 Z=0
             G0 Z{homing_zhop} F{z_drop_speed}
-            M84 # Motor off to "unhome" z for functional safety. This will also unhome all previously homed axis
         {% endif %}
     {% endif %}
 

--- a/macros/base/homing/homing_overide.cfg
+++ b/macros/base/homing/homing_overide.cfg
@@ -20,6 +20,8 @@ gcode:
     {% set y_position_endstop = printer["configfile"].config["stepper_y"]["position_endstop"]|float %}
     {% set x_position_center = printer.toolhead.axis_maximum.x|int/2 - printer.toolhead.axis_minimum.x|int/2 %}
     {% set y_position_center = printer.toolhead.axis_maximum.y|int/2 - printer.toolhead.axis_minimum.y|int/2 %}
+    
+    {% set homing_force_zhop = printer["gcode_macro _USER_VARIABLES"].homing_force_zhop %}
 
 
     {% if probe_type_enabled == "dockable" %}
@@ -95,11 +97,20 @@ gcode:
             {% set X, Y, Z = True, True, True %}
         {% endif %}
     {% else %}
-        {% if (printer.toolhead.position.z < homing_zhop) %}
-            {% if verbose %}
-                { action_respond_info("Z too low, performing ZHOP") }
+        {% if ('z' in printer.toolhead.homed_axes) %}
+            {% if (printer.toolhead.position.z < homing_zhop) %}
+                {% if verbose %}
+                    { action_respond_info("Z too low, performing ZHOP") }
+                {% endif %}
+                G0 Z{homing_zhop} F{z_drop_speed}
             {% endif %}
+        {% elif homing_force_zhop}
+            {% if verbose %}
+                { action_respond_info("Forcing z hop without homing z.") }
+            {% endif %}
+            SET_KINEMATIC_POSITION X=0 Y=0 Z=0
             G0 Z{homing_zhop} F{z_drop_speed}
+            M84 # Motor off to "unhome" z for functional safety. This will also unhome all previously homed axis
         {% endif %}
     {% endif %}
 

--- a/macros/base/homing/homing_overide.cfg
+++ b/macros/base/homing/homing_overide.cfg
@@ -77,14 +77,7 @@ gcode:
     {% endif %}
 
     G90
-
-    {% if (printer.toolhead.position.z < homing_zhop) %}
-        {% if verbose %}
-            { action_respond_info("Z too low, performing ZHOP") }
-        {% endif %}
-        G0 Z{homing_zhop} F{z_drop_speed}
-    {% endif %}
-
+    
     {% if Z %}
         {% if ('z' in printer.toolhead.homed_axes) %}
             {% if (printer.toolhead.position.z < homing_zhop) %}
@@ -100,6 +93,13 @@ gcode:
             SET_KINEMATIC_POSITION X=0 Y=0 Z=0
             G0 Z{homing_zhop} F{z_drop_speed}
             {% set X, Y, Z = True, True, True %}
+        {% endif %}
+    {% else %}
+        {% if (printer.toolhead.position.z < homing_zhop) %}
+            {% if verbose %}
+                { action_respond_info("Z too low, performing ZHOP") }
+            {% endif %}
+            G0 Z{homing_zhop} F{z_drop_speed}
         {% endif %}
     {% endif %}
 

--- a/macros/base/homing/homing_overide.cfg
+++ b/macros/base/homing/homing_overide.cfg
@@ -108,9 +108,9 @@ gcode:
             {% if verbose %}
                 { action_respond_info("Forcing z hop without homing z.") }
             {% endif %}
-            SET_KINEMATIC_POSITION X=0 Y=0 Z=0
+            SET_KINEMATIC_POSITION Z=0
             G0 Z{homing_zhop} F{z_drop_speed}
-            M84 # Motor off to "unhome" z for functional safety. This will also unhome all previously homed axis
+            M84 Z
         {% endif %}
     {% endif %}
 

--- a/macros/base/homing/homing_overide.cfg
+++ b/macros/base/homing/homing_overide.cfg
@@ -21,9 +21,6 @@ gcode:
     {% set x_position_center = printer.toolhead.axis_maximum.x|int/2 - printer.toolhead.axis_minimum.x|int/2 %}
     {% set y_position_center = printer.toolhead.axis_maximum.y|int/2 - printer.toolhead.axis_minimum.y|int/2 %}
     
-    {% set homing_force_zhop = printer["gcode_macro _USER_VARIABLES"].homing_force_zhop %}
-
-
     {% if probe_type_enabled == "dockable" %}
         _CHECK_PROBE action=query
     {% endif %}
@@ -97,21 +94,12 @@ gcode:
             {% set X, Y, Z = True, True, True %}
         {% endif %}
     {% else %}
-        {% if ('z' in printer.toolhead.homed_axes) %}
-            {% if (printer.toolhead.position.z < homing_zhop) %}
-                {% if verbose %}
-                    { action_respond_info("Z too low, performing ZHOP") }
-                {% endif %}
-                G0 Z{homing_zhop} F{z_drop_speed}
-            {% endif %}
-        {% elif homing_force_zhop}
-            {% if verbose %}
-                { action_respond_info("Forcing z hop without homing z.") }
-            {% endif %}
-            SET_KINEMATIC_POSITION Z=0
-            G0 Z{homing_zhop} F{z_drop_speed}
-            M84 Z
+        {% if verbose %}
+            { action_respond_info("Homing X or Y while Z is not homed, forcing ZHOP") }
         {% endif %}
+        SET_KINEMATIC_POSITION Z=0
+        G0 Z{homing_zhop} F{z_drop_speed}
+        M84 Z
     {% endif %}
 
 

--- a/macros/base/homing/homing_overide.cfg
+++ b/macros/base/homing/homing_overide.cfg
@@ -77,7 +77,7 @@ gcode:
     {% endif %}
 
     G90
-    
+
     {% if Z %}
         {% if ('z' in printer.toolhead.homed_axes) %}
             {% if (printer.toolhead.position.z < homing_zhop) %}

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -40,6 +40,10 @@ variable_force_homing_in_start_print: False
 ## Z hop before homing to avoid grinding
 ## the bed due to the gantry sag
 variable_homing_zhop: 5
+## Z hop before homing only X/Y without Z. In case while probing erroring out.
+## For functional safety reasons, if the following option is set to true, 
+## a M84 (Motors off) will be issued between forced Z hop and X/Y homing
+variable_homing_force_zhop: False
 
 ## XY axis homing order and backoff distance after touching the endstops
 variable_homing_first: "X" # can be set to "Y" first

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -40,10 +40,6 @@ variable_force_homing_in_start_print: False
 ## Z hop before homing to avoid grinding
 ## the bed due to the gantry sag
 variable_homing_zhop: 5
-## Z hop before homing only X/Y without Z. In case while probing erroring out.
-## For functional safety reasons, if the following option is set to true, 
-## a M84 (Motors off) will be issued between forced Z hop and X/Y homing
-variable_homing_force_zhop: False
 
 ## XY axis homing order and backoff distance after touching the endstops
 variable_homing_first: "X" # can be set to "Y" first


### PR DESCRIPTION
if X or Y is homed without z, it is always checked if a zhop is required. This helps if the probing was errored out, leaving the nozzle on the bed.