### PR TITLE
Remove "position_endstop: 0" from Trident Z config files.

### DIFF
--- a/config/hardware/axis/Z/Trident_1.8d_TR8x4_z.cfg
+++ b/config/hardware/axis/Z/Trident_1.8d_TR8x4_z.cfg
@@ -2,7 +2,6 @@
 rotation_distance: 4
 microsteps: 32
 full_steps_per_rotation: 200
-position_endstop: 0
 
 [tmc2209 stepper_z]
 interpolate: False

--- a/config/hardware/axis/Z/Trident_1.8d_TR8x8_z.cfg
+++ b/config/hardware/axis/Z/Trident_1.8d_TR8x8_z.cfg
@@ -2,7 +2,6 @@
 rotation_distance: 8
 microsteps: 32
 full_steps_per_rotation: 200
-position_endstop: 0
 
 [tmc2209 stepper_z]
 interpolate: False


### PR DESCRIPTION
Klipper errors out when activating Voron Tap probe.