### PR TITLE
Deleted old "tap_heating" from voron tap config

### DIFF
--- a/config/hardware/probes/tap_probe.cfg
+++ b/config/hardware/probes/tap_probe.cfg
@@ -1,6 +1,6 @@
 [gcode_macro _USER_VARIABLES]
 variable_probe_type_enabled: "vorontap"
-variable_startprint_actions: "bed_soak", "extruder_preheating", "chamber_soak", "clean", "tap_heating", "tilt_calib", "z_offset", "bedmesh", "extruder_heating", "purge", "clean", "primeline"
+variable_startprint_actions: "bed_soak", "extruder_preheating", "chamber_soak", "clean", "tilt_calib", "z_offset", "bedmesh", "extruder_heating", "purge", "clean", "primeline"
 gcode:
 
 # TAP probe definition also include the probe management macro directly from here


### PR DESCRIPTION
Somehow missed this when doing patch rework.