### PR TITLE
Fix BTT SKR Mini E3 v3 config

### DIFF
--- a/user_templates/mcu_defaults/main/BTT_SKR_Mini_E3_v3.cfg
+++ b/user_templates/mcu_defaults/main/BTT_SKR_Mini_E3_v3.cfg
@@ -8,7 +8,7 @@
 serial: /dev/serial/by-id/change-me-to-the-correct-mcu-path
 ##--------------------------------------------------------------------
 
-[include config/mcu_definitions/BTT_SKR_E3mini_v3.cfg] # Do not remove this line
+[include config/mcu_definitions/main/BTT_SKR_Mini_E3_v3.cfg] # Do not remove this line
 [board_pins SKR_mini_e3_mcu]
 mcu: mcu
 aliases:


### PR DESCRIPTION
Hi! In #177 I realized that the config path I had included in my MCU default path was broken.  I fixed and verified on my printer, but didn't have a chance to commit until after the PR was merged.

This PR fixes that MCU template file.