### PR TITLE
Case light off when printing  at define layer + command to turn On/Off case light

### DIFF
--- a/config/hardware/lights/fcob_white.cfg
+++ b/config/hardware/lights/fcob_white.cfg
@@ -1,6 +1,7 @@
 # White lights using 24V (example: white fcob)
 [gcode_macro _USER_VARIABLES]
 variable_light_enabled: True
+variable_caselight_off_layer_enabled = True
 variable_light_pin_name: "caselight"
 gcode:
 

--- a/config/hardware/lights/fcob_white.cfg
+++ b/config/hardware/lights/fcob_white.cfg
@@ -7,6 +7,7 @@ gcode:
 
 # Also include directly the white lights control macros from here
 [include ../../../macros/hardware_functions/caselights.cfg]
+[include ../../../macros/miscs/framelight.cfg]
 
 
 [output_pin caselight]

--- a/config/hardware/lights/fcob_white.cfg
+++ b/config/hardware/lights/fcob_white.cfg
@@ -1,7 +1,6 @@
 # White lights using 24V (example: white fcob)
 [gcode_macro _USER_VARIABLES]
 variable_light_enabled: True
-variable_caselight_off_layer_enabled = True
 variable_light_pin_name: "caselight"
 gcode:
 

--- a/config/hardware/lights/neopixel_caselight.cfg
+++ b/config/hardware/lights/neopixel_caselight.cfg
@@ -1,6 +1,7 @@
 # Neopixel leds used as general printer lights
 [gcode_macro _USER_VARIABLES]
 variable_status_leds_caselight_enabled = True
+variable_caselight_off_layer_enabled = True
 variable_status_leds_caselight_led_name: "caselight"
 gcode:
 

--- a/config/hardware/lights/neopixel_caselight.cfg
+++ b/config/hardware/lights/neopixel_caselight.cfg
@@ -7,6 +7,7 @@ gcode:
 
 # Also include directly the leds control macros from here 
 [include ../../../macros/hardware_functions/status_leds.cfg]
+[include ../../../macros/miscs/framelight.cfg]
 
 
 [neopixel caselight]

--- a/config/hardware/lights/neopixel_caselight.cfg
+++ b/config/hardware/lights/neopixel_caselight.cfg
@@ -1,7 +1,6 @@
 # Neopixel leds used as general printer lights
 [gcode_macro _USER_VARIABLES]
 variable_status_leds_caselight_enabled = True
-variable_caselight_off_layer_enabled = True
 variable_status_leds_caselight_led_name: "caselight"
 gcode:
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,7 +38,6 @@ Also, add custom print end G-code to your slicer:
 END_PRINT
 ```
   > **Addition** for case light (fcob white or neopixel) users:
-  >
   > By default, Klippain don't turn off case lights on printing progress.
   > If you want you can add this two lines in your slicer to turn off caselight at a specific layer. ex: for SuperSlicer in before layer change gcode:
   > `SET_PRINT_STATS_INFO CURRENT_LAYER={layer_num} _STOP_CASELIGHT_LAYER_CHANGE LAYER=X`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,7 +40,9 @@ END_PRINT
   > **Addition** for case light (fcob white or neopixel) users:
   >
   > By default, Klippain don't turn off case lights on printing progress.
-  > If you want you can add this two lines in your slicer to turn off caselight at a specific layer. ex: for SuperSlicer in before layer change gcode:
-  > `SET_PRINT_STATS_INFO CURRENT_LAYER={layer_num}
-  > _STOP_CASELIGHT_LAYER_CHANGE LAYER=X`
-  > where X is the value of the layer.
+  > If you want, you can add this two lines in your slicer to turn off caselight at a specific layer. ex: for SuperSlicer in "After layer change G-code" in Printer Settings:
+  >```
+  >SET_PRINT_STATS_INFO CURRENT_LAYER={layer_num}
+  >_STOP_CASELIGHT_LAYER_CHANGE LAYER=X
+  >```
+

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,6 +38,7 @@ Also, add custom print end G-code to your slicer:
 END_PRINT
 ```
   > **Addition** for case light (fcob white or neopixel) users:
+  >
   > By default, Klippain don't turn off case lights on printing progress.
   > If you want you can add this two lines in your slicer to turn off caselight at a specific layer. ex: for SuperSlicer in before layer change gcode:
   > `SET_PRINT_STATS_INFO CURRENT_LAYER={layer_num} _STOP_CASELIGHT_LAYER_CHANGE LAYER=X`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -40,7 +40,7 @@ END_PRINT
   > **Addition** for case light (fcob white or neopixel) users:
   >
   > By default, Klippain don't turn off case lights on printing progress.
-  > If you want, you can add this two lines in your slicer to turn off caselight at a specific layer. ex: for SuperSlicer in "After layer change G-code" in Printer Settings:
+  > If you want, you can add this two lines in your slicer to turn off caselight at a specific layer. ex: for SuperSlicer in "Before layer change G-code" in Printer Settings:
   >```
   >SET_PRINT_STATS_INFO CURRENT_LAYER={layer_num}
   >_STOP_CASELIGHT_LAYER_CHANGE LAYER=X

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,5 +41,6 @@ END_PRINT
   >
   > By default, Klippain don't turn off case lights on printing progress.
   > If you want you can add this two lines in your slicer to turn off caselight at a specific layer. ex: for SuperSlicer in before layer change gcode:
-  > `SET_PRINT_STATS_INFO CURRENT_LAYER={layer_num} _STOP_CASELIGHT_LAYER_CHANGE LAYER=X`
+  > `SET_PRINT_STATS_INFO CURRENT_LAYER={layer_num}
+  > _STOP_CASELIGHT_LAYER_CHANGE LAYER=X`
   > where X is the value of the layer.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,3 +37,9 @@ Also, add custom print end G-code to your slicer:
 ```
 END_PRINT
 ```
+  > **Addition** for case light (fcob white or neopixel) users:
+  >
+  > By default, Klippain don't turn off case lights on printing progress.
+  > If you want you can add this two lines in your slicer to turn off caselight at a specific layer. ex: for SuperSlicer in before layer change gcode:
+  > `SET_PRINT_STATS_INFO CURRENT_LAYER={layer_num} _STOP_CASELIGHT_LAYER_CHANGE LAYER=X`
+  > where X is the value of the layer.

--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -37,6 +37,7 @@ gcode:
     {% set light_intensity_start_print = printer["gcode_macro _USER_VARIABLES"].light_intensity_start_print %}
     {% set light_intensity_printing = printer["gcode_macro _USER_VARIABLES"].light_intensity_printing %}
     {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set status_leds_caselight_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
     {% set force_homing_in_start_print = printer["gcode_macro _USER_VARIABLES"].force_homing_in_start_print %}
     {% set ercf_enabled = printer["gcode_macro _USER_VARIABLES"].ercf_enabled %}
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
@@ -149,7 +150,7 @@ gcode:
         LIGHT_ON S={light_intensity_printing}
     {% endif %}
 
-    {% if printer['gcode_macro _USER_VARIABLES'].caselight_off_layer_enabled %}
+    {% if status_leds_caselight_enabled or light_enabled %}
         _RESET_LAYER_GCODE
     {% endif %}
 

--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -149,6 +149,10 @@ gcode:
         LIGHT_ON S={light_intensity_printing}
     {% endif %}
 
+    {% if printer['gcode_macro _USER_VARIABLES'].caselight_off_layer_enabled %}
+        _RESET_LAYER_GCODE
+    {% endif %}
+
     {% if verbose %}
         RESPOND MSG="Start printing !"
     {% endif %}

--- a/macros/hardware_functions/caselights.cfg
+++ b/macros/hardware_functions/caselights.cfg
@@ -1,3 +1,4 @@
+
 [gcode_macro LIGHT_OFF]
 gcode:
     {% set light_pin_name = printer["gcode_macro _USER_VARIABLES"].light_pin_name %}

--- a/macros/hardware_functions/status_leds.cfg
+++ b/macros/hardware_functions/status_leds.cfg
@@ -92,11 +92,36 @@ gcode:
     {% set transmit = params.TRANSMIT|default(1) %}
 
     _SET_LEDS_BY_NAME LEDS="nozzle" COLOR="off" TRANSMIT={transmit}
-	
+
+[gcode_macro SET_CASELIGHT_LEDS_ON]
+gcode:
+    {% set transmit = params.TRANSMIT|default(1) %}
+
+    {% if printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
+        {% set color_name = params.COLOR|default('on')|lower %}
+        _SET_ALLLEDS_BY_NAME LEDS="caselight" COLOR={color_name} TRANSMIT=1
+    {% elif ["gcode_macro _USER_VARIABLES"].light_enabled %}
+        LIGHT_ON
+    {% else %}
+        RESPOND MSG="No case light defined!!!"
+    {% endif %}
+
+[gcode_macro SET_CASELIGHT_LEDS_OFF]
+gcode:
+    {% set transmit = params.TRANSMIT|default(1) %}
+
+    {% if printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
+        _SET_ALLLEDS_BY_NAME LEDS="caselight" COLOR="off" TRANSMIT={transmit}
+    {% elif ["gcode_macro _USER_VARIABLES"].light_enabled %}
+        LIGHT_OFF
+    {% else %}
+        RESPOND MSG="No case light defined!!!"
+    {% endif %}
+
 [gcode_macro STATUS_LEDS]
 gcode:
     {% set color = params.COLOR|default('off')|lower %}
- 
+
     {% set status_color = {
         'ready': {
             'logo': 'standby',
@@ -169,7 +194,7 @@ gcode:
             'nozzle': 'error',
             'caselight': 'error',
             'minidisplay': 'error'
-        }   
+        }
     } %}
 
     {% if not (color in status_color) %}
@@ -187,4 +212,31 @@ gcode:
 
     {% if printer["gcode_macro _USER_VARIABLES"].status_leds_minidisplay_enabled %}
         _SET_ALLLEDS_BY_NAME LEDS="minidisplay" COLOR={status_color[color].minidisplay} TRANSMIT=1
+    {% endif %}
+
+[gcode_macro _RESET_LAYER_GCODE]
+description: Clears scheduled gcode commands and state for all layers.
+  Usage: _RESET_LAYER_GCODE
+gcode:
+  SET_PRINT_STATS_INFO TOTAL_LAYER="{0}" CURRENT_LAYER="{0}"
+
+[gcode_macro AFTER_LAYER_CHANGE]
+gcode:
+    {% set cur_layers = printer.print_stats.info.current_layer|int %}
+    {% set light_enabled = printer["gcode_macro _USER_VARIABLES"].light_enabled %}
+    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+
+    {% if printer['gcode_macro _USER_VARIABLES'].caselight_off_layer_enabled %}
+    {% set caselight_off_layer_height = printer["gcode_macro _USER_VARIABLES"].caselight_off_layer_height|int %}
+        {% if status_leds_enabled %}
+            {%if cur_layers > caselight_off_layer_height %}
+                _SET_CASELIGHT_LEDS_OFF
+            {% endif %}
+        {% endif %}
+
+        {% if light_enabled %}
+            {%if cur_layers > caselight_off_layer_height %}
+                LIGHT_OFF
+            {% endif %}
+        {% endif %}
     {% endif %}

--- a/macros/hardware_functions/status_leds.cfg
+++ b/macros/hardware_functions/status_leds.cfg
@@ -93,31 +93,6 @@ gcode:
 
     _SET_LEDS_BY_NAME LEDS="nozzle" COLOR="off" TRANSMIT={transmit}
 
-[gcode_macro SET_CASELIGHT_LEDS_ON]
-gcode:
-    {% set transmit = params.TRANSMIT|default(1) %}
-
-    {% if printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
-        {% set color_name = params.COLOR|default('on')|lower %}
-        _SET_ALLLEDS_BY_NAME LEDS="caselight" COLOR={color_name} TRANSMIT=1
-    {% elif ["gcode_macro _USER_VARIABLES"].light_enabled %}
-        LIGHT_ON
-    {% else %}
-        RESPOND MSG="No case light defined!!!"
-    {% endif %}
-
-[gcode_macro SET_CASELIGHT_LEDS_OFF]
-gcode:
-    {% set transmit = params.TRANSMIT|default(1) %}
-
-    {% if printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
-        _SET_ALLLEDS_BY_NAME LEDS="caselight" COLOR="off" TRANSMIT={transmit}
-    {% elif ["gcode_macro _USER_VARIABLES"].light_enabled %}
-        LIGHT_OFF
-    {% else %}
-        RESPOND MSG="No case light defined!!!"
-    {% endif %}
-
 [gcode_macro STATUS_LEDS]
 gcode:
     {% set color = params.COLOR|default('off')|lower %}
@@ -212,31 +187,4 @@ gcode:
 
     {% if printer["gcode_macro _USER_VARIABLES"].status_leds_minidisplay_enabled %}
         _SET_ALLLEDS_BY_NAME LEDS="minidisplay" COLOR={status_color[color].minidisplay} TRANSMIT=1
-    {% endif %}
-
-[gcode_macro _RESET_LAYER_GCODE]
-description: Clears scheduled gcode commands and state for all layers.
-  Usage: _RESET_LAYER_GCODE
-gcode:
-  SET_PRINT_STATS_INFO TOTAL_LAYER="{0}" CURRENT_LAYER="{0}"
-
-[gcode_macro AFTER_LAYER_CHANGE]
-gcode:
-    {% set cur_layers = printer.print_stats.info.current_layer|int %}
-    {% set light_enabled = printer["gcode_macro _USER_VARIABLES"].light_enabled %}
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
-
-    {% if printer['gcode_macro _USER_VARIABLES'].caselight_off_layer_enabled %}
-    {% set caselight_off_layer_height = printer["gcode_macro _USER_VARIABLES"].caselight_off_layer_height|int %}
-        {% if status_leds_enabled %}
-            {%if cur_layers > caselight_off_layer_height %}
-                _SET_CASELIGHT_LEDS_OFF
-            {% endif %}
-        {% endif %}
-
-        {% if light_enabled %}
-            {%if cur_layers > caselight_off_layer_height %}
-                LIGHT_OFF
-            {% endif %}
-        {% endif %}
     {% endif %}

--- a/macros/miscs/framelight.cfg
+++ b/macros/miscs/framelight.cfg
@@ -1,0 +1,38 @@
+[gcode_macro SET_CASELIGHT_LEDS_ON]
+gcode:
+    {% set transmit = params.TRANSMIT|default(1) %}
+
+    {% if printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
+        {% set color_name = params.COLOR|default('on')|lower %}
+        _SET_ALLLEDS_BY_NAME LEDS="caselight" COLOR={color_name} TRANSMIT=1
+    {% elif printer["gcode_macro _USER_VARIABLES"].light_enabled %}
+        LIGHT_ON
+    {% endif %}
+
+[gcode_macro SET_CASELIGHT_LEDS_OFF]
+gcode:
+    {% set transmit = params.TRANSMIT|default(1) %}
+
+    {% if printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
+        _SET_ALLLEDS_BY_NAME LEDS="caselight" COLOR="off" TRANSMIT={transmit}
+    {% elif printer["gcode_macro _USER_VARIABLES"].light_enabled %}
+        LIGHT_OFF
+    {% endif %}
+
+[gcode_macro STOP_CASELIGHT_LAYER_CHANGE]
+gcode:
+    {% set cur_layers = printer.print_stats.info.current_layer|int %}
+    {% set caselight_off_layer_height = params.LAYER|default(printer["gcode_macro _USER_VARIABLES"].ercf_unload_on_end_print)|int %}
+
+    {% if printer['gcode_macro _USER_VARIABLES'].caselight_off_layer_enabled %}
+    {% set caselight_off_layer_height = printer["gcode_macro _USER_VARIABLES"].caselight_off_layer_height|int %}
+        {%if cur_layers > caselight_off_layer_height %}
+            _SET_CASELIGHT_LEDS_OFF
+        {% endif %}
+    {% endif %}
+
+[gcode_macro _RESET_LAYER_GCODE]
+description: Clears scheduled gcode commands and state for all layers.
+  Usage: _RESET_LAYER_GCODE
+gcode:
+  SET_PRINT_STATS_INFO TOTAL_LAYER="{0}" CURRENT_LAYER="{0}"

--- a/macros/miscs/framelight.cfg
+++ b/macros/miscs/framelight.cfg
@@ -19,15 +19,14 @@ gcode:
         LIGHT_OFF
     {% endif %}
 
-[gcode_macro STOP_CASELIGHT_LAYER_CHANGE]
+[gcode_macro _STOP_CASELIGHT_LAYER_CHANGE]
 gcode:
     {% set cur_layers = printer.print_stats.info.current_layer|int %}
-#    {% set caselight_off_layer_height = params.LAYER|default(printer["gcode_macro _USER_VARIABLES"].ercf_unload_on_end_print)|int %}
     {% set caselight_off_layer_height = params.LAYER|default(2)|int %}
 
     {% if printer['gcode_macro _USER_VARIABLES'].caselight_off_layer_enabled %}
         {%if cur_layers > caselight_off_layer_height %}
-            _SET_CASELIGHT_LEDS_OFF
+            SET_CASELIGHT_LEDS_OFF
         {% endif %}
     {% endif %}
 

--- a/macros/miscs/framelight.cfg
+++ b/macros/miscs/framelight.cfg
@@ -22,10 +22,10 @@ gcode:
 [gcode_macro STOP_CASELIGHT_LAYER_CHANGE]
 gcode:
     {% set cur_layers = printer.print_stats.info.current_layer|int %}
-    {% set caselight_off_layer_height = params.LAYER|default(printer["gcode_macro _USER_VARIABLES"].ercf_unload_on_end_print)|int %}
+#    {% set caselight_off_layer_height = params.LAYER|default(printer["gcode_macro _USER_VARIABLES"].ercf_unload_on_end_print)|int %}
+    {% set caselight_off_layer_height = params.LAYER|default(2)|int %}
 
     {% if printer['gcode_macro _USER_VARIABLES'].caselight_off_layer_enabled %}
-    {% set caselight_off_layer_height = printer["gcode_macro _USER_VARIABLES"].caselight_off_layer_height|int %}
         {%if cur_layers > caselight_off_layer_height %}
             _SET_CASELIGHT_LEDS_OFF
         {% endif %}

--- a/macros/miscs/framelight.cfg
+++ b/macros/miscs/framelight.cfg
@@ -1,7 +1,7 @@
 [gcode_macro SET_CASELIGHT_LEDS_ON]
 description: Start case light - In case you have!!!
-  Usage: for fcbo white light: SET_CASELIGHT_LEDS_ON
-  Usage: for neopixel light:   SET_CASELIGHT_LEDS_ON COLOR= (optional COLOR default is "on")
+  Usage: for fcbo white light: SET_CASELIGHT_LEDS_ON S= (optional S parameter for light intensity 0-100 default is 100)
+  Usage: for neopixel light:   SET_CASELIGHT_LEDS_ON COLOR= (optional COLOR parameter default is "on")
 gcode:
     {% set transmit = params.TRANSMIT|default(1) %}
     {% set status_leds_caselight_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
@@ -11,9 +11,8 @@ gcode:
         {% set color_name = params.COLOR|default('on')|lower %}
         _SET_ALLLEDS_BY_NAME LEDS="caselight" COLOR={color_name} TRANSMIT=1
     {% elif light_enabled %}
-        LIGHT_ON
-    {% else %}
-        RESPOND MSG="No caselight !!!"
+        {% set S = params.S|default(100)|float %}
+        LIGHT_ON S={S}
     {% endif %}
 
 [gcode_macro SET_CASELIGHT_LEDS_OFF]
@@ -27,8 +26,6 @@ gcode:
         _SET_ALLLEDS_BY_NAME LEDS="caselight" COLOR="off" TRANSMIT={transmit}
     {% elif light_enabled %}
         LIGHT_OFF
-    {% else %}
-        RESPOND MSG="No caselight !!!"
     {% endif %}
 
 [gcode_macro _STOP_CASELIGHT_LAYER_CHANGE]
@@ -44,8 +41,6 @@ gcode:
         {%if cur_layers > caselight_off_layer_height %}
             SET_CASELIGHT_LEDS_OFF
         {% endif %}
-    {% else %}
-        RESPOND MSG="No caselight initialised in Klippain !!!"
     {% endif %}
 
 [gcode_macro _RESET_LAYER_GCODE]

--- a/macros/miscs/framelight.cfg
+++ b/macros/miscs/framelight.cfg
@@ -1,37 +1,51 @@
 [gcode_macro SET_CASELIGHT_LEDS_ON]
 gcode:
     {% set transmit = params.TRANSMIT|default(1) %}
+    {% set status_leds_caselight_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
+    {% set light_enabled = printer["gcode_macro _USER_VARIABLES"].light_enabled %}
 
-    {% if printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
+    {% if status_leds_caselight_enabled %}
         {% set color_name = params.COLOR|default('on')|lower %}
         _SET_ALLLEDS_BY_NAME LEDS="caselight" COLOR={color_name} TRANSMIT=1
-    {% elif printer["gcode_macro _USER_VARIABLES"].light_enabled %}
+    {% elif light_enabled %}
         LIGHT_ON
+    {% else %}
+        RESPOND MSG="No caselight !!!"
     {% endif %}
 
 [gcode_macro SET_CASELIGHT_LEDS_OFF]
 gcode:
     {% set transmit = params.TRANSMIT|default(1) %}
+    {% set status_leds_caselight_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
+    {% set light_enabled = printer["gcode_macro _USER_VARIABLES"].light_enabled %}
 
-    {% if printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
+    {% if status_leds_caselight_enabled %}
         _SET_ALLLEDS_BY_NAME LEDS="caselight" COLOR="off" TRANSMIT={transmit}
-    {% elif printer["gcode_macro _USER_VARIABLES"].light_enabled %}
+    {% elif light_enabled %}
         LIGHT_OFF
+    {% else %}
+        RESPOND MSG="No caselight !!!"
     {% endif %}
 
 [gcode_macro _STOP_CASELIGHT_LAYER_CHANGE]
+description: Stop case light at define layer (X).
+  Usage: _STOP_CASELIGHT_LAYER_CHANGE LAYER=X 
 gcode:
+    {% set status_leds_caselight_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
+    {% set light_enabled = printer["gcode_macro _USER_VARIABLES"].light_enabled %}
     {% set cur_layers = printer.print_stats.info.current_layer|int %}
     {% set caselight_off_layer_height = params.LAYER|default(2)|int %}
 
-    {% if printer['gcode_macro _USER_VARIABLES'].caselight_off_layer_enabled %}
+    {% if status_leds_caselight_enabled or light_enabled %}
         {%if cur_layers > caselight_off_layer_height %}
             SET_CASELIGHT_LEDS_OFF
         {% endif %}
+    {% else %}
+        RESPOND MSG="No caselight initialised in Klippain !!!"
     {% endif %}
 
 [gcode_macro _RESET_LAYER_GCODE]
 description: Clears scheduled gcode commands and state for all layers.
   Usage: _RESET_LAYER_GCODE
 gcode:
-  SET_PRINT_STATS_INFO TOTAL_LAYER="{0}" CURRENT_LAYER="{0}"
+    SET_PRINT_STATS_INFO TOTAL_LAYER="{0}" CURRENT_LAYER="{0}"

--- a/macros/miscs/framelight.cfg
+++ b/macros/miscs/framelight.cfg
@@ -1,4 +1,7 @@
 [gcode_macro SET_CASELIGHT_LEDS_ON]
+description: Start case light - In case you have!!!
+  Usage: for fcbo white light: SET_CASELIGHT_LEDS_ON
+  Usage: for neopixel light:   SET_CASELIGHT_LEDS_ON COLOR= (optional COLOR default is "on")
 gcode:
     {% set transmit = params.TRANSMIT|default(1) %}
     {% set status_leds_caselight_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
@@ -14,6 +17,7 @@ gcode:
     {% endif %}
 
 [gcode_macro SET_CASELIGHT_LEDS_OFF]
+description: Stop case light - In case you have!!!
 gcode:
     {% set transmit = params.TRANSMIT|default(1) %}
     {% set status_leds_caselight_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -209,6 +209,9 @@ variable_resonnance_test_point_xy: -1, -1
 variable_resonnance_test_z_clearance: 50
 
 
+## Control layer hight stop Caselight (if installed in the machine)
+variable_caselight_off_layer_height = 2
+
 ## SteathBurner minidisplay and case leds colors (if installed in the machine)
 variable_status_leds_colors: {
         'logo': {

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -209,9 +209,6 @@ variable_resonnance_test_point_xy: -1, -1
 variable_resonnance_test_z_clearance: 50
 
 
-## Control layer hight stop Caselight (if installed in the machine)
-variable_caselight_off_layer_height = 2
-
 ## SteathBurner minidisplay and case leds colors (if installed in the machine)
 variable_status_leds_colors: {
         'logo': {
@@ -222,7 +219,7 @@ variable_status_leds_colors: {
             'homing': {'r': 0.0, 'g': 0.6, 'b': 0.2, 'w': 0.0},
             'leveling': {'r': 0.5, 'g': 0.1, 'b': 0.4, 'w': 0.0},
             'meshing': {'r': 0.2, 'g': 1.0, 'b': 0.0, 'w': 0.0},
-            'on': {'r': 0.8, 'g': 0.8, 'b': 0.8, 'w':1.0},										  
+            'on': {'r': 0.8, 'g': 0.8, 'b': 0.8, 'w':1.0},
             'off': {'r': 0.0, 'g': 0.0, 'b': 0.0, 'w': 0.0},
             'printing': {'r': 1.0, 'g': 0.0, 'b': 0.0, 'w': 0.0},
             'standby': {'r': 0.01, 'g': 0.01, 'b': 0.01, 'w': 0.1},


### PR DESCRIPTION
This PR adds an option allowing:
- add gcode:
to turn on `SET_CASELIGHT_LED_ON` and turn off: `SET_CASELIGHT_LED_OFF` the case light of the frame.
- And also the possibility during printing to turn off the caselight from a certain layer (X); by default set to layer 2
To be done you need to add the following commands in the before layer change gcode of the slicer (SuperSlicer exemple):
`SET_PRINT_STATS_INFO CURRENT_LAYER={layer_num}
_STOP_CASELIGHT_LAYER_CHANGE LAYER=X`
where X is the value of the layer.