### PR TITLE
fixed line start in /proc/cpuinfo

### DIFF
--- a/scripts/system_info.py
+++ b/scripts/system_info.py
@@ -55,7 +55,7 @@ def get_unknown_board_info():
     try:
         with open('/proc/cpuinfo', 'r') as f:
             for line in f:
-                if line.startswith('Hardware') or line.startswith('Model name'):
+                if line.startswith('Hardware') or line.startswith('Model'):
                     return line.split(':')[1].strip()
         with open('/etc/os-release', 'r') as f:
             for line in f:


### PR DESCRIPTION
When i checked my startup, I found strange "unknown" system info printed for my genuine Pi4. When checking the file, I found the culprit:
![image](https://github.com/Frix-x/klippain/assets/102791900/2af090d6-aa68-4ec1-811b-debc19661516)

The script checks for "Model name", instead of "Model" as shown in the screenshot. I removed the " name" section of "Model name". This should fix this issue and still be compatible for "Model name" since only "Model" is checked