### PR TITLE
Cancel_print.cfg caselights

### DIFF
--- a/macros/base/cancel_print.cfg
+++ b/macros/base/cancel_print.cfg
@@ -46,7 +46,7 @@ gcode:
     {% endif %}
 
     {% if light_enabled %}
-        LIGHT_OFF
+        LIGHT_ON S={light_intensity_end_print}
     {% endif %}
     {% if status_leds_enabled %}
         STATUS_LEDS COLOR="OFF"


### PR DESCRIPTION
Edited to match the END_PRINT functionality for the case lights to use the light_intensity_end_print value. Per Azi V2.4971 https://discord.com/channels/460117602945990666/1096701708643614820/1125890377782665386