### PR TITLE
SystemInfo now showing all Raspberry models

### DIFF
--- a/scripts/system_info.py
+++ b/scripts/system_info.py
@@ -42,12 +42,11 @@ def check_wsl():
     return False
 
 def get_pi_model():
-    if "arm" in platform.machine():
-        try:
-            model_info = subprocess.check_output(['cat', '/sys/firmware/devicetree/base/model'], universal_newlines=True)
-            return model_info
-        except subprocess.CalledProcessError:
-            return None
+    try:
+        model_info = subprocess.check_output(['cat', '/sys/firmware/devicetree/base/model'], universal_newlines=True)
+        if 'raspberry pi' in model_info.lower(): return model_info
+    except subprocess.CalledProcessError:
+        return None
     else:
         return None
 


### PR DESCRIPTION
As owner of a 64bit raspberry pi (aarch64) i was kinda frustrated that it didn't show up correctly.
I looked around and found a good solution to get all future raspberry models covered as well.

the current implementation checks only on "arm" in platform, and there are more platforms named arm than just the raspberry pi.

Tested it successfully with my pi4