### PR TITLE
Default Filter time on end print

### DIFF
--- a/macros/base/end_print.cfg
+++ b/macros/base/end_print.cfg
@@ -11,7 +11,7 @@ gcode:
     {% set light_enabled = printer["gcode_macro _USER_VARIABLES"].light_enabled %}
     {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
-    {% set default_filter_time = printer["gcode_macro _USER_VARIABLES"].default_time_on_end_print %}
+    {% set default_filter_time = printer["gcode_macro _USER_VARIABLES"].default_time_on_end_print|default(600)|int %}
 
     PARK
 

--- a/macros/base/end_print.cfg
+++ b/macros/base/end_print.cfg
@@ -11,6 +11,7 @@ gcode:
     {% set light_enabled = printer["gcode_macro _USER_VARIABLES"].light_enabled %}
     {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
+    {% set default_filter_time = printer["gcode_macro _USER_VARIABLES"].default_time_on_end_print %}
 
     PARK
 
@@ -47,7 +48,7 @@ gcode:
     # If a filter is connected, filter the air at full power
     # for a couple of min before stopping everything
     {% if filter_enabled %}
-        {% set FILTER_TIME = params.FILTER_TIME|default(600)|int %}
+        {% set FILTER_TIME = params.FILTER_TIME|default(default_filter_time)|int %}
         START_FILTER SPEED=1
         UPDATE_DELAYED_GCODE ID=_STOP_FILTER_DELAYED DURATION={FILTER_TIME}
     {% endif %}

--- a/macros/base/end_print.cfg
+++ b/macros/base/end_print.cfg
@@ -11,7 +11,7 @@ gcode:
     {% set light_enabled = printer["gcode_macro _USER_VARIABLES"].light_enabled %}
     {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
-    {% set default_filter_time = printer["gcode_macro _USER_VARIABLES"].default_time_on_end_print|default(600)|int %}
+    {% set filter_default_time = printer["gcode_macro _USER_VARIABLES"].filter_default_time_on_end_print|default(600)|int %}
 
     PARK
 
@@ -48,7 +48,7 @@ gcode:
     # If a filter is connected, filter the air at full power
     # for a couple of min before stopping everything
     {% if filter_enabled %}
-        {% set FILTER_TIME = params.FILTER_TIME|default(default_filter_time)|int %}
+        {% set FILTER_TIME = params.FILTER_TIME|default(filter_default_time)|int %}
         START_FILTER SPEED=1
         UPDATE_DELAYED_GCODE ID=_STOP_FILTER_DELAYED DURATION={FILTER_TIME}
     {% endif %}

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -182,6 +182,12 @@ variable_ercf_unload_on_cancel_print: False
 variable_ercf_unload_on_end_print: True
 variable_ercf_reset_stats_on_start_print: False
 
+################################################
+## Filter specific variables
+################################################
+## This section is only considered if a filter is available (and enabled)
+
+variable_filter_default_time_on_end_print = 600 # seconds
 
 ################################################
 # Other hardware options used in the macros


### PR DESCRIPTION
currently playing with my filters and found out, that there is no variable to configure the default duration for filter at the end print macro. this PR should address this "issue". the use of FILTER_TIME on END_PRINT is still possible and there is no change to that logic.
