### PR TITLE
fixed check on startup for ercf

### DIFF
--- a/macros/miscs/startup.cfg
+++ b/macros/miscs/startup.cfg
@@ -127,10 +127,9 @@ gcode:
 
 [gcode_macro _INIT_CHECK_ERCF]
 gcode:
-    {% if not printer.ercf.enabled %}
+    {% if printer.ercf is not defined %}
         { action_raise_error("ERCF is enabled in Klippain, but Happy Hare, the supported ERCF backend software is not detected. Please install it now from https://github.com/moggieuk/ERCF-Software-V3 !") }
     {% endif %}
-
 
 [gcode_macro _INIT_USERCUSTOM]
 gcode:


### PR DESCRIPTION
@Benoitone contacted me based on a verification issue on the ercf startup macro. after some talk, we found out, that the check is not really working. I updated the logic in this PR to test for the existence of printer.ercf as base instead of a none working check for printer.ercf.enabled as true.