### PR TITLE
added check for exclude_object availability

### DIFF
--- a/macros/calibration/adaptive_bed_mesh.cfg
+++ b/macros/calibration/adaptive_bed_mesh.cfg
@@ -89,7 +89,7 @@ gcode:
         {% endif %}
     {% endif %}
 
-    {% if coordinatesFound == false %}
+    {% if not coordinatesFound %}
         # If no SIZE parameter and no [exclude_object] tags, then we want to do a nominal bed mesh
         # so nothing to do here...
         RESPOND MSG="No info about the first layer coordinates, doing a nominal bed mesh instead of adaptive"

--- a/macros/calibration/adaptive_bed_mesh.cfg
+++ b/macros/calibration/adaptive_bed_mesh.cfg
@@ -69,22 +69,28 @@ gcode:
 
     # 2 ----- GET FIRST LAYER COORDINATES and SIZE -------------------------------------
     # If the SIZE parameter is defined and not a dummy placeholder, we use it to do the adaptive bed mesh logic
+    {% set coordinatesFound = false %}
     {% if params.SIZE is defined and params.SIZE != "0_0_0_0" %}
         RESPOND MSG="Got a SIZE parameter for the adaptive bed mesh"
         {% set xMinSpec, yMinSpec, xMaxSpec, yMaxSpec = params.SIZE.split('_')|map('trim')|map('int') %}
+        {% set coordinatesFound = true %}
 
-    {% elif printer.exclude_object.objects %}
-        # Else if SIZE is not defined, we fallback to use the [exclude_object] tags
-        # This method is derived from Kyleisah KAMP repository: https://github.com/kyleisah/Klipper-Adaptive-Meshing-Purging)
-        RESPOND MSG="No SIZE parameter, using the [exclude_object] tags for the adaptive bed mesh"
-        {% set eo_points = printer.exclude_object.objects|map(attribute='polygon')|sum(start=[]) %}
-        {% set xMinSpec = eo_points|map(attribute=0)|min %}
-        {% set yMinSpec = eo_points|map(attribute=1)|min %}
-        {% set xMaxSpec = eo_points|map(attribute=0)|max %}
-        {% set yMaxSpec = eo_points|map(attribute=1)|max %}
+    {% elif printer.exclude_object is defined %}
+        {% if printer.exclude_object.objects %}
+            # Else if SIZE is not defined, we fallback to use the [exclude_object] tags
+            # This method is derived from Kyleisah KAMP repository: https://github.com/kyleisah/Klipper-Adaptive-Meshing-Purging)
+            RESPOND MSG="No SIZE parameter, using the [exclude_object] tags for the adaptive bed mesh"
+            {% set eo_points = printer.exclude_object.objects|map(attribute='polygon')|sum(start=[]) %}
+            {% set xMinSpec = eo_points|map(attribute=0)|min %}
+            {% set yMinSpec = eo_points|map(attribute=1)|min %}
+            {% set xMaxSpec = eo_points|map(attribute=0)|max %}
+            {% set yMaxSpec = eo_points|map(attribute=1)|max %}
+            {% set coordinatesFound = true %}
+        {% endif %}
+    {% endif %}
 
-    {% else %}
-        # Else if no SIZE parameter and no [exclude_object] tags, then we want to do a nominal bed mesh
+    {% if coordinatesFound == false %}
+        # If no SIZE parameter and no [exclude_object] tags, then we want to do a nominal bed mesh
         # so nothing to do here...
         RESPOND MSG="No info about the first layer coordinates, doing a nominal bed mesh instead of adaptive"
     {% endif %}


### PR DESCRIPTION
If Bed Mesh is called without a setting up exclude_objects, an error comes up. This is related to missing checks if something is (not) defined.
I added a variable and an additional check to fix the reported issue. The variable is required to prevent double else statements, which looks ugly