### PR TITLE
Add switch sensor config

### DIFF
--- a/config/hardware/filament_sensors/switch_sensor.cfg
+++ b/config/hardware/filament_sensors/switch_sensor.cfg
@@ -1,0 +1,12 @@
+[filament_switch_sensor runout_sensor]
+extruder: extruder
+#   The name of the extruder section this sensor is associated with.
+#   This parameter must be provided.
+switch_pin:RUNOUT_SENSOR
+pause_on_runout:False
+#runout_gcode:
+#insert_gcode:
+#event_delay:
+#pause_delay:
+#   See the "filament_switch_sensor" section for a description of the
+#   above parameters.

--- a/user_templates/printer.cfg
+++ b/user_templates/printer.cfg
@@ -155,6 +155,7 @@
 # ------------------------------------------------------------------ FILAMENT SENSORS ----> Select only one line
 ### --------------------------------------------------------------------------------------
 # [include config/hardware/filament_sensors/motion_sensor.cfg]
+# [include config/hardware/filament_sensors/switch_sensor.cfg]
 # ----------------------------------------------------------------------------------------
 
 


### PR DESCRIPTION
As motion sensors will fail for a generic switch sensor due to not detecting the minimum amount of motion, I've provided a config and printer.cfg option for those who have a regular runout switch sensor.

ref: https://discord.com/channels/460117602945990666/1096701708643614820/1136286792920858794