### PR TITLE
Add support for sensorless homing on CoreXZ & Cartesian

### DIFF
--- a/macros/base/homing/homing_override.cfg
+++ b/macros/base/homing/homing_override.cfg
@@ -3,6 +3,7 @@
 axes: xyz
 gcode:
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
+    {% set kinematics = printer["configfile"].config["printer"]["kinematics"] %}
     {% set probe_type_enabled = printer["gcode_macro _USER_VARIABLES"].probe_type_enabled %}
     {% set homing_zhop = printer["gcode_macro _USER_VARIABLES"].homing_zhop|float %}
     {% set homing_travel_speed = printer["gcode_macro _USER_VARIABLES"].homing_travel_speed * 60 %}
@@ -11,6 +12,7 @@ gcode:
     {% set sensorless_current_factor = printer["gcode_macro _USER_VARIABLES"].sensorless_current_factor / 100 %}
     {% set x_driver = printer["gcode_macro _USER_VARIABLES"].x_driver %}
     {% set y_driver = printer["gcode_macro _USER_VARIABLES"].y_driver %}
+    {% set z_driver = printer["gcode_macro _USER_VARIABLES"].z_driver %}
     {% set z_drop_speed = printer["gcode_macro _USER_VARIABLES"].z_drop_speed * 60 %}
     {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
@@ -98,6 +100,10 @@ gcode:
             {% endif %}
             SET_KINEMATIC_POSITION X=0 Y=0 Z=0
             G0 Z{homing_zhop} F{z_drop_speed}
+            {% if sensorless_homing_enabled and kinematics == "corexz" %}
+                # Wait for 2s for stallguard registers to clear
+                G4 P2000
+            {% endif %}
             {% set X, Y, Z = True, True, True %}
         {% endif %}
     {% endif %}
@@ -108,20 +114,43 @@ gcode:
                 { action_respond_info("Homing X") }
             {% endif %}
             {% if sensorless_homing_enabled %}
-                {% set old_current_x = printer.configfile.config[x_driver ~ ' stepper_x'].run_current|float %}
-                {% set old_current_y = printer.configfile.config[y_driver ~ ' stepper_y'].run_current|float %}
-                {% set new_current_x = sensorless_current_factor * old_current_x %}
-                {% set new_current_y = sensorless_current_factor * old_current_y %}
-                SET_TMC_CURRENT STEPPER=stepper_x CURRENT={new_current_x}
-                SET_TMC_CURRENT STEPPER=stepper_y CURRENT={new_current_y}
-                M400
+                {% if kinematics == "corexy" %}
+                    {% set old_current_x = printer.configfile.config[x_driver ~ ' stepper_x'].run_current|float %}
+                    {% set old_current_y = printer.configfile.config[y_driver ~ ' stepper_y'].run_current|float %}
+                    {% set new_current_x = sensorless_current_factor * old_current_x %}
+                    {% set new_current_y = sensorless_current_factor * old_current_y %}
+                    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={new_current_x}
+                    SET_TMC_CURRENT STEPPER=stepper_y CURRENT={new_current_y}
+                    M400
+                {% elif kinematics == "corexz" %}
+                    {% set old_current_x = printer.configfile.config[x_driver ~ ' stepper_x'].run_current|float %}
+                    {% set old_current_z = printer.configfile.config[z_driver ~ ' stepper_z'].run_current|float %}
+                    {% set new_current_x = sensorless_current_factor * old_current_x %}
+                    {% set new_current_z = sensorless_current_factor * old_current_z %}
+                    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={new_current_x}
+                    SET_TMC_CURRENT STEPPER=stepper_z CURRENT={new_current_z}
+                    M400
+                {% elif kinematics == "cartesian" %}
+                    {% set old_current_x = printer.configfile.config[x_driver ~ ' stepper_x'].run_current|float %}
+                    {% set new_current_x = sensorless_current_factor * old_current_x %}
+                    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={new_current_x}
+                    M400
+                {% endif %}
             {% endif %}
             G28 X0
             G1 X{x_position_endstop + x_homing_backoff} F{homing_travel_speed}
             {% if sensorless_homing_enabled %}
-                G4 P1000
-                SET_TMC_CURRENT STEPPER=stepper_x CURRENT={old_current_x}
-                SET_TMC_CURRENT STEPPER=stepper_y CURRENT={old_current_y}
+                {% if kinematics == "corexy" %}
+                    G4 P2000
+                    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={old_current_x}
+                    SET_TMC_CURRENT STEPPER=stepper_y CURRENT={old_current_y}
+                {% elif kinematics == "corexz" %}
+                    G4 P2000
+                    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={old_current_x}
+                    SET_TMC_CURRENT STEPPER=stepper_z CURRENT={old_current_z}
+                {% elif kinematics == "cartesian" %}
+                    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={old_current_x}
+                {% endif %}
             {% endif %}
         {% endif %}
         {% if Y %} # Home y
@@ -129,20 +158,38 @@ gcode:
                 { action_respond_info("Homing Y") }
             {% endif %}
             {% if sensorless_homing_enabled %}
-                {% set old_current_x = printer.configfile.config[x_driver ~ ' stepper_x'].run_current|float %}
-                {% set old_current_y = printer.configfile.config[y_driver ~ ' stepper_y'].run_current|float %}
-                {% set new_current_x = sensorless_current_factor * old_current_x %}
-                {% set new_current_y = sensorless_current_factor * old_current_y %}
-                SET_TMC_CURRENT STEPPER=stepper_x CURRENT={new_current_x}
-                SET_TMC_CURRENT STEPPER=stepper_y CURRENT={new_current_y}
-                M400
+                {% if kinematics == "corexy" %}
+                    {% set old_current_x = printer.configfile.config[x_driver ~ ' stepper_x'].run_current|float %}
+                    {% set old_current_y = printer.configfile.config[y_driver ~ ' stepper_y'].run_current|float %}
+                    {% set new_current_x = sensorless_current_factor * old_current_x %}
+                    {% set new_current_y = sensorless_current_factor * old_current_y %}
+                    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={new_current_x}
+                    SET_TMC_CURRENT STEPPER=stepper_y CURRENT={new_current_y}
+                    M400
+                {% elif kinematics == "corexz" %}
+                    {% set old_current_y = printer.configfile.config[y_driver ~ ' stepper_y'].run_current|float %}
+                    {% set new_current_y = sensorless_current_factor * old_current_y %}
+                    SET_TMC_CURRENT STEPPER=stepper_y CURRENT={new_current_y}
+                    M400
+                {% elif kinematics == "cartesian" %}
+                    {% set old_current_y = printer.configfile.config[y_driver ~ ' stepper_y'].run_current|float %}
+                    {% set new_current_y = sensorless_current_factor * old_current_y %}
+                    SET_TMC_CURRENT STEPPER=stepper_y CURRENT={new_current_y}
+                    M400
+                {% endif %}
             {% endif %}
             G28 Y0
             G1 Y{y_position_endstop + y_homing_backoff} F{homing_travel_speed}
             {% if sensorless_homing_enabled %}
-                G4 P1000
-                SET_TMC_CURRENT STEPPER=stepper_x CURRENT={old_current_x}
-                SET_TMC_CURRENT STEPPER=stepper_y CURRENT={old_current_y}
+                {% if kinematics == "corexy" %}
+                    G4 P2000
+                    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={old_current_x}
+                    SET_TMC_CURRENT STEPPER=stepper_y CURRENT={old_current_y}
+                {% elif kinematics == "corexz" %}
+                    SET_TMC_CURRENT STEPPER=stepper_y CURRENT={old_current_y}
+                {% elif kinematics == "cartesian" %}
+                    SET_TMC_CURRENT STEPPER=stepper_y CURRENT={old_current_y}
+                {% endif %}
             {% endif %}
         {% endif %}
 
@@ -152,20 +199,38 @@ gcode:
                 { action_respond_info("Homing Y") }
             {% endif %}
             {% if sensorless_homing_enabled %}
-                {% set old_current_x = printer.configfile.config[x_driver ~ ' stepper_x'].run_current|float %}
-                {% set old_current_y = printer.configfile.config[y_driver ~ ' stepper_y'].run_current|float %}
-                {% set new_current_x = sensorless_current_factor * old_current_x %}
-                {% set new_current_y = sensorless_current_factor * old_current_y %}
-                SET_TMC_CURRENT STEPPER=stepper_x CURRENT={new_current_x}
-                SET_TMC_CURRENT STEPPER=stepper_y CURRENT={new_current_y}
-                M400
+                {% if kinematics == "corexy" %}
+                    {% set old_current_x = printer.configfile.config[x_driver ~ ' stepper_x'].run_current|float %}
+                    {% set old_current_y = printer.configfile.config[y_driver ~ ' stepper_y'].run_current|float %}
+                    {% set new_current_x = sensorless_current_factor * old_current_x %}
+                    {% set new_current_y = sensorless_current_factor * old_current_y %}
+                    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={new_current_x}
+                    SET_TMC_CURRENT STEPPER=stepper_y CURRENT={new_current_y}
+                    M400
+                {% elif kinematics == "corexz" %}
+                    {% set old_current_y = printer.configfile.config[y_driver ~ ' stepper_y'].run_current|float %}
+                    {% set new_current_y = sensorless_current_factor * old_current_y %}
+                    SET_TMC_CURRENT STEPPER=stepper_y CURRENT={new_current_y}
+                    M400
+                {% elif kinematics == "cartesian" %}
+                    {% set old_current_y = printer.configfile.config[y_driver ~ ' stepper_y'].run_current|float %}
+                    {% set new_current_y = sensorless_current_factor * old_current_y %}
+                    SET_TMC_CURRENT STEPPER=stepper_y CURRENT={new_current_y}
+                    M400
+                {% endif %}
             {% endif %}
             G28 Y0
             G1 Y{y_position_endstop + y_homing_backoff} F{homing_travel_speed}
             {% if sensorless_homing_enabled %}
-                G4 P1000
-                SET_TMC_CURRENT STEPPER=stepper_x CURRENT={old_current_x}
-                SET_TMC_CURRENT STEPPER=stepper_y CURRENT={old_current_y}
+                {% if kinematics == "corexy" %}
+                    G4 P2000
+                    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={old_current_x}
+                    SET_TMC_CURRENT STEPPER=stepper_y CURRENT={old_current_y}
+                {% elif kinematics == "corexz" %}
+                    SET_TMC_CURRENT STEPPER=stepper_y CURRENT={old_current_y}
+                {% elif kinematics == "cartesian" %}
+                    SET_TMC_CURRENT STEPPER=stepper_y CURRENT={old_current_y}
+                {% endif %}
             {% endif %}
         {% endif %}
         {% if X %} # Home x
@@ -173,20 +238,43 @@ gcode:
                 { action_respond_info("Homing X") }
             {% endif %}
             {% if sensorless_homing_enabled %}
-                {% set old_current_x = printer.configfile.config[x_driver ~ ' stepper_x'].run_current|float %}
-                {% set old_current_y = printer.configfile.config[y_driver ~ ' stepper_y'].run_current|float %}
-                {% set new_current_x = sensorless_current_factor * old_current_x %}
-                {% set new_current_y = sensorless_current_factor * old_current_y %}
-                SET_TMC_CURRENT STEPPER=stepper_x CURRENT={new_current_x}
-                SET_TMC_CURRENT STEPPER=stepper_y CURRENT={new_current_y}
-                M400
+                {% if kinematics == "corexy" %}
+                    {% set old_current_x = printer.configfile.config[x_driver ~ ' stepper_x'].run_current|float %}
+                    {% set old_current_y = printer.configfile.config[y_driver ~ ' stepper_y'].run_current|float %}
+                    {% set new_current_x = sensorless_current_factor * old_current_x %}
+                    {% set new_current_y = sensorless_current_factor * old_current_y %}
+                    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={new_current_x}
+                    SET_TMC_CURRENT STEPPER=stepper_y CURRENT={new_current_y}
+                    M400
+                {% elif kinematics == "corexz" %}
+                    {% set old_current_x = printer.configfile.config[x_driver ~ ' stepper_x'].run_current|float %}
+                    {% set old_current_z = printer.configfile.config[z_driver ~ ' stepper_z'].run_current|float %}
+                    {% set new_current_x = sensorless_current_factor * old_current_x %}
+                    {% set new_current_z = sensorless_current_factor * old_current_z %}
+                    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={new_current_x}
+                    SET_TMC_CURRENT STEPPER=stepper_z CURRENT={new_current_z}
+                    M400
+                {% elif kinematics == "cartesian" %}
+                    {% set old_current_x = printer.configfile.config[x_driver ~ ' stepper_x'].run_current|float %}
+                    {% set new_current_x = sensorless_current_factor * old_current_x %}
+                    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={new_current_x}
+                    M400
+                {% endif %}
             {% endif %}
             G28 X0
             G1 X{x_position_endstop + x_homing_backoff} F{homing_travel_speed}
             {% if sensorless_homing_enabled %}
-                G4 P1000
-                SET_TMC_CURRENT STEPPER=stepper_x CURRENT={old_current_x}
-                SET_TMC_CURRENT STEPPER=stepper_y CURRENT={old_current_y}
+                {% if kinematics == "corexy" %}
+                    G4 P2000
+                    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={old_current_x}
+                    SET_TMC_CURRENT STEPPER=stepper_y CURRENT={old_current_y}
+                {% elif kinematics == "corexz" %}
+                    G4 P2000
+                    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={old_current_x}
+                    SET_TMC_CURRENT STEPPER=stepper_z CURRENT={old_current_z}
+                {% elif kinematics == "cartesian" %}
+                    SET_TMC_CURRENT STEPPER=stepper_x CURRENT={old_current_x}
+                {% endif %}
             {% endif %}
         {% endif %}
 


### PR DESCRIPTION
Hi Frix!

New PR here to tweak the homing override such that CoreXZ behaves a little better with sensorless homing.  I've tested this PR on my VSW and it appears to be working nicely.

Specifically, I added a new variable to track kinematic type, then I use that variable in homing_override.cfg to control which motors have their current reduced during homing (no change for corexy).  Additionally, I increased the 1s wait to 2s between homing moves to allow stallguard registers to clear.  CoreXZ also required a 2s wait after the initial Z hop for the same reason.

Let me know if you need any changes or additional testing and I'd be happy to do it!