### PR TITLE
Adding bed mesh for MK52 beds

### DIFF
--- a/config/software/bed_mesh/bed_mesh_120mm.cfg
+++ b/config/software/bed_mesh/bed_mesh_120mm.cfg
@@ -12,7 +12,7 @@ gcode:
 
 [bed_mesh]
 speed: 350
-horizontal_move_z: 12
+horizontal_move_z: 20
 mesh_min: 7, 21.75
 mesh_max: 105, 113
 probe_count: 5, 5

--- a/config/software/bed_mesh/bed_mesh_300mm.cfg
+++ b/config/software/bed_mesh/bed_mesh_300mm.cfg
@@ -12,7 +12,7 @@ gcode:
 
 [bed_mesh]
 speed: 350
-horizontal_move_z: 12
+horizontal_move_z: 20
 mesh_min: 25, 25
 mesh_max: 275, 275
 probe_count: 9, 9

--- a/config/software/bed_mesh/bed_mesh_350mm.cfg
+++ b/config/software/bed_mesh/bed_mesh_350mm.cfg
@@ -12,7 +12,7 @@ gcode:
 
 [bed_mesh]
 speed: 350
-horizontal_move_z: 12
+horizontal_move_z: 20
 mesh_min: 25, 25
 mesh_max: 325, 325
 probe_count: 9, 9

--- a/config/software/bed_mesh/bed_mesh_mk52.cfg
+++ b/config/software/bed_mesh/bed_mesh_mk52.cfg
@@ -9,14 +9,12 @@ gcode:
 # And also include the adaptive mesh macro at the same time
 [include ../../../macros/calibration/adaptive_bed_mesh.cfg]
 
-
 [bed_mesh]
 speed: 350
 horizontal_move_z: 20
-mesh_min: 25, 25
-mesh_max: 225, 225
+mesh_min: 25, 35
+mesh_max: 225, 215
 probe_count: 7, 7
 fade_start: 0.6
 fade_end: 10.0
 algorithm: bicubic
-zero_reference_position: 125, 125

--- a/user_templates/overrides.cfg
+++ b/user_templates/overrides.cfg
@@ -64,3 +64,14 @@
 # [stepper_z3]
 # dir_pin: !Z3_DIR
 
+
+#-------------------------#
+#   Probe Offsets         #
+#-------------------------#
+
+## Here is an example of some overrides for bed probes. These frequently have calibrated offsets for xyz,
+## and many will need them during setup. If you need to set these, just uncomment the following lines.
+# [probe]
+# x_offset: -1.85
+# y_offset: 29.3
+# z_offset: 12.6

--- a/user_templates/printer.cfg
+++ b/user_templates/printer.cfg
@@ -204,6 +204,7 @@
 # [include config/software/bed_mesh/bed_mesh_250mm.cfg]
 # [include config/software/bed_mesh/bed_mesh_300mm.cfg]
 # [include config/software/bed_mesh/bed_mesh_350mm.cfg]
+# [include config/software/bed_mesh/bed_mesh_mk52.cfg]
 
 ### If you need to specify a bed mesh configuration for a custom sized printer, use your
 ### overrides.cfg file instead. These defaults are only made for common machines sizes


### PR DESCRIPTION
Hi @Frix-x!

This PR is a minor update to enable bed mesh's on VSW and other Mk52-based printbeds :)

* adds a bed mesh config for the VSW's MK52 bed size (without zero_reference_index since VSW doesn't usually have one)
* slightly increases bed mesh's z hop between probes to account for larger probes (like the unklicky BFP which has a 12.6mm Z offset on my printer) on all bed_mesh configs. The increase was from 12->20mm.
* Amended the printer.cfg to offer this bed size as an option
* Updated overrides.cfg to add commonly changed probe settings (for non-TAP probes)

Let me know if you need me to change anything!
-Nick