### PR TITLE
Exposing SPI and IO pins on SKR Mini E3 v3 config

### DIFF
--- a/config/mcu_definitions/main/BTT_SKR_Mini_E3_v3.cfg
+++ b/config/mcu_definitions/main/BTT_SKR_Mini_E3_v3.cfg
@@ -17,10 +17,10 @@ aliases:
 
     MCU_FAN0=PC6 , MCU_FAN1=PC7 , MCU_FAN2=PB15 ,
 
-    MCU_SERVOS=PA1 ,
+    # Z-Probe Header
+    MCU_SERVOS=PA1 , MCU_PROBE=PC14 ,
 
-    MCU_PROBE=PC14 ,
-
+    # Neopixel1 Header
     MCU_NEOPIXEL=PA8 ,
 
     # EXP1 header
@@ -29,3 +29,9 @@ aliases:
     EXP1_5=PB9   , EXP1_6=PA10  ,  # Key in the socket on this side
     EXP1_7=<RST> , EXP1_8=PA9   ,
     EXP1_9=PA15  , EXP1_10=PB5  ,
+
+    # SPI1 header
+    MCU_SPI1_MOSI=PA7 , MCU_SPI1_MISO=PA6 , MCU_SPI1_SCK=PA5 , MCU_SPI1_CS=PD9 ,
+
+    # I/O header
+    MCU_IO0=PD0 , MCU_IO1=PD2 , MCU_IO2=PD3 , MCU_IO3=PD4 , MCU_IO4=PD5

--- a/docs/pinout.md
+++ b/docs/pinout.md
@@ -77,3 +77,4 @@ For more information on the boards and pinouts, please see directly the manufact
   - [BTT Manta 8P](https://github.com/bigtreetech/Manta-M8P)
   - [Fly SHT](https://mellow.klipper.cn/#/board/fly_sht36_42/)
   - [BTT EBB](https://github.com/bigtreetech/EBB)
+  - [BTT SKR Mini E3](https://github.com/bigtreetech/BIGTREETECH-SKR-mini-E3)


### PR DESCRIPTION
Hi @Frix-x!

Another PR, this one for additional pins on the SKR Mini E3 V3.  There are two new groups I added, the pins on the SPI1 header and the pins that BTT exposes as GPIO.  There wasn't a Frix name for GPIO yet that I saw, so I made one up. I can obviously change it but felt that a simple IO0, IO1, etc made the most sense.

The SPI pins aren't exposed on the pinout doc that BTT shares (the just call them SPI1 MOSI, CS, etc), but looking at the schematics these are what these pins go to.  I use them for SW SPI for my Fysetc Mini12684 display for example.

I also updated the pinout.md doc to include the link to the SKR Mini E3 repo as well :)

Let me know if you like this change and if you want any additional changes!

Best,
Nick