### PR TITLE
remove usage of `homing_positive_dir`

### DIFF
--- a/config/hardware/axis/X/default_speed.cfg
+++ b/config/hardware/axis/X/default_speed.cfg
@@ -1,4 +1,3 @@
 [stepper_x]
 homing_speed: 60
 homing_retract_dist: 0
-homing_positive_dir: true

--- a/config/hardware/axis/Y/default_speed.cfg
+++ b/config/hardware/axis/Y/default_speed.cfg
@@ -1,4 +1,3 @@
 [stepper_y]
 homing_speed: 60
 homing_retract_dist: 0
-homing_positive_dir: true

--- a/macros/base/homing/homing_override.cfg
+++ b/macros/base/homing/homing_override.cfg
@@ -315,10 +315,12 @@ gcode:
         G28 Z0
 
         G91
-        {% if printer["configfile"].settings["stepper_z"]["homing_positive_dir"] == False %}
-            G0 Z{homing_zhop} F{z_drop_speed} # small Z hop to avoid grinding the bed (as we should be close to Z0 right now)
-        {% elif printer["configfile"].settings["stepper_z"]["homing_positive_dir"] == True %}
-            G0 Z-{homing_zhop} F{z_drop_speed} # small Z move in the opposite direction to avoid staying on the endstop (not dangerous since we should be at Z max)
+        {% if (printer.toolhead.position.z < homing_zhop) %}
+            # small Z hop to avoid grinding the bed (as we should be at Z min right now)
+            G0 Z{homing_zhop} F{z_drop_speed}
+        {% else %}
+            # small Z move in the opposite direction to avoid staying on the endstop (not dangerous since we should be at Z max)
+            G0 Z-{homing_zhop} F{z_drop_speed}
         {% endif %}
         G90
 

--- a/macros/base/homing/homing_override.cfg
+++ b/macros/base/homing/homing_override.cfg
@@ -315,12 +315,14 @@ gcode:
         G28 Z0
 
         G91
-        {% if (printer.toolhead.position.z < homing_zhop) %}
-            # small Z hop to avoid grinding the bed (as we should be at Z min right now)
-            G0 Z{homing_zhop} F{z_drop_speed}
-        {% else %}
-            # small Z move in the opposite direction to avoid staying on the endstop (not dangerous since we should be at Z max)
-            G0 Z-{homing_zhop} F{z_drop_speed}
+        {% if (homing_zhop > 0) %}
+            {% if (printer.toolhead.position.z < homing_zhop) %}
+                # small Z hop to avoid grinding the bed (as we should be at Z min right now)
+                G0 Z{homing_zhop} F{z_drop_speed}
+            {% else %}
+                # small Z move in the opposite direction to avoid staying on the endstop (not dangerous since we should be at Z max)
+                G0 Z-{homing_zhop} F{z_drop_speed}
+            {% endif %}
         {% endif %}
         G90
 

--- a/macros/base/homing/homing_override.cfg
+++ b/macros/base/homing/homing_override.cfg
@@ -315,14 +315,10 @@ gcode:
         G28 Z0
 
         G91
-        {% if (homing_zhop > 0) %}
-            {% if (printer.toolhead.position.z < homing_zhop) %}
-                # small Z hop to avoid grinding the bed (as we should be at Z min right now)
-                G0 Z{homing_zhop} F{z_drop_speed}
-            {% else %}
-                # small Z move in the opposite direction to avoid staying on the endstop (not dangerous since we should be at Z max)
-                G0 Z-{homing_zhop} F{z_drop_speed}
-            {% endif %}
+        {% if printer["configfile"].settings["stepper_z"]["homing_positive_dir"] == False %}
+            G0 Z{homing_zhop} F{z_drop_speed} # small Z hop to avoid grinding the bed (as we should be close to Z0 right now)
+        {% elif printer["configfile"].settings["stepper_z"]["homing_positive_dir"] == True %}
+            G0 Z-{homing_zhop} F{z_drop_speed} # small Z move in the opposite direction to avoid staying on the endstop (not dangerous since we should be at Z max)
         {% endif %}
         G90
 


### PR DESCRIPTION
As stated in [Klipper docs](https://www.klipper3d.org/Config_Reference.html?h=homing_positive_dir#stepper): "It is better to use the default than to specify this parameter. The default is true if `position_endstop` is near `position_max` and false if near `position_min`."

Including this parameter seems to be at best redundant and at worst potentially damaging for printers that home at axis minimum.