### PR TITLE
Fix bug in hotend_heater_ctrl.cfg that allowed probing while nozzle is hot

### DIFF
--- a/macros/base/probing/generic_probe.cfg
+++ b/macros/base/probing/generic_probe.cfg
@@ -35,6 +35,7 @@ gcode:
             { action_respond_info('Extruder temperature target of %.1fC is too high for TAP probing, lowering to %.1fC' % (TARGET_TEMP, tap_max_probing_temp)) }
             M106 S255 ; 100% the part cooling fan to help the extruder cooling
             M109 S{tap_max_probing_temp}
+            G4 P270000 ; Wait for nozzle to cool down before probing (5 min for reasonable worst case scenario of 300C)
             M106 S0   ; Stop the part cooling fan
         {% else %}
             # Temperature target is already low enough, but nozzle may still be too hot

--- a/macros/base/probing/generic_probe.cfg
+++ b/macros/base/probing/generic_probe.cfg
@@ -35,7 +35,6 @@ gcode:
             { action_respond_info('Extruder temperature target of %.1fC is too high for TAP probing, lowering to %.1fC' % (TARGET_TEMP, tap_max_probing_temp)) }
             M106 S255 ; 100% the part cooling fan to help the extruder cooling
             M109 S{tap_max_probing_temp}
-            G4 P270000 ; Wait for nozzle to cool down before probing (5 min for reasonable worst case scenario of 300C)
             M106 S0   ; Stop the part cooling fan
         {% else %}
             # Temperature target is already low enough, but nozzle may still be too hot

--- a/macros/helpers/bed_heater_ctrl.cfg
+++ b/macros/helpers/bed_heater_ctrl.cfg
@@ -6,12 +6,19 @@
 rename_existing: M190.1
 gcode:
     {% set S = params.S|float %}
+    {% set actual_temp = printer.heater_bed.temperature|float %}
 
     {% set fix_heaters_temperature_settle = printer["gcode_macro _USER_VARIABLES"].fix_heaters_temperature_settle %}
 
     {% if fix_heaters_temperature_settle %}
         M140 {% for p in params %}{'%s%s' % (p, params[p])}{% endfor %}
-        TEMPERATURE_WAIT SENSOR=heater_bed MINIMUM={S}
+        {% if S != 0 %}
+            {% if actual_temp <= S %}
+                TEMPERATURE_WAIT SENSOR=heater_bed MINIMUM={S}
+            {% else %}
+                TEMPERATURE_WAIT SENSOR=heater_bed MAXIMUM={S}
+            {% endif %}   
+        {% endif %}
     {% else %}
         M190.1 {% for p in params %}{'%s%s' % (p, params[p])}{% endfor %}
     {% endif %}

--- a/macros/helpers/hotend_heater_ctrl.cfg
+++ b/macros/helpers/hotend_heater_ctrl.cfg
@@ -2,16 +2,24 @@
 # on low thermal inertia devices such as the BambuLabs hotend. This allows a
 # shunt of the "waiting time" during temperature settle in case there is some problems
 
+
 [gcode_macro M109]
 rename_existing: M109.1
 gcode:
     {% set S = params.S|float %}
+    {% set actual_temp = printer.extruder.temperature|float %}
 
-    {% set fix_heaters_temperature_settle = printer["gcode_macro _USER_VARIABLES"].fix_heaters_temperature_settle %}
+    {% set fix_heaters_temperature_settle = printer["gcode_macro _GLOBAL_VARIABLES"].fix_heaters_temperature_settle %}
 
     {% if fix_heaters_temperature_settle %}
         M104 {% for p in params %}{'%s%s' % (p, params[p])}{% endfor %}
-        TEMPERATURE_WAIT SENSOR=extruder MAXIMUM={S}
+        {% if S != 0 %}
+            {% if actual_temp <= S %}
+                TEMPERATURE_WAIT SENSOR=extruder MINIMUM={S}
+            {% else %}
+                TEMPERATURE_WAIT SENSOR=extruder MAXIMUM={S}
+            {% endif %}   
+        {% endif %}
     {% else %}
         M109.1 {% for p in params %}{'%s%s' % (p, params[p])}{% endfor %}
     {% endif %}

--- a/macros/helpers/hotend_heater_ctrl.cfg
+++ b/macros/helpers/hotend_heater_ctrl.cfg
@@ -11,7 +11,7 @@ gcode:
 
     {% if fix_heaters_temperature_settle %}
         M104 {% for p in params %}{'%s%s' % (p, params[p])}{% endfor %}
-        TEMPERATURE_WAIT SENSOR=extruder MINIMUM={S}
+        TEMPERATURE_WAIT SENSOR=extruder MAXIMUM={S}
     {% else %}
         M109.1 {% for p in params %}{'%s%s' % (p, params[p])}{% endfor %}
     {% endif %}

--- a/macros/helpers/hotend_heater_ctrl.cfg
+++ b/macros/helpers/hotend_heater_ctrl.cfg
@@ -9,7 +9,7 @@ gcode:
     {% set S = params.S|float %}
     {% set actual_temp = printer.extruder.temperature|float %}
 
-    {% set fix_heaters_temperature_settle = printer["gcode_macro _GLOBAL_VARIABLES"].fix_heaters_temperature_settle %}
+    {% set fix_heaters_temperature_settle = printer["gcode_macro _USER_VARIABLES"].fix_heaters_temperature_settle %}
 
     {% if fix_heaters_temperature_settle %}
         M104 {% for p in params %}{'%s%s' % (p, params[p])}{% endfor %}


### PR DESCRIPTION
Fixes #301.

This is inelegant, but this prevents the nozzle from touching the bed surface when too hot in all cases. Let me know if you think of something better or want to tweak it, but at least it can be fixed for now. I'm guessing at the dwell time of 5 min in a worst case scenario. It could probably be less, but I only have a Revo and that cools down quick so I assume other hotness have considerably more thermal mass than mine.