### PR TITLE
Rampon firmware for Kusba and etc.

### DIFF
--- a/config/hardware/accelerometers/adxl345_usb_rampon.cfg
+++ b/config/hardware/accelerometers/adxl345_usb_rampon.cfg
@@ -1,0 +1,25 @@
+# This ADXL file is dedicated to be used with ADXL boards
+# connected over USB to the pi as dedicated and standalone ADXL-MCU boards
+
+# This include KUSBA, ...
+
+
+# You need to override the following to be able to set the proper serial in your overrides.cfg file
+[mcu adxl]
+serial: /dev/serial/by-id/xxx
+
+[adxl345]
+cs_pin: adxl:CS
+axes_map: x,y,z
+
+[resonance_tester]
+accel_chip: adxl345
+probe_points:
+    -1,-1,-1
+
+
+# Include the IS calibration macros to unlock them when
+# an accelerometer is installed on the machine
+[include ../../../macros/helpers/resonance_override.cfg]
+[include ../../../macros/calibration/IS_shaper_calibrate.cfg]
+[include ../../../macros/calibration/IS_vibrations_measurement.cfg]

--- a/user_templates/printer.cfg
+++ b/user_templates/printer.cfg
@@ -164,6 +164,7 @@
 ### --------------------------------------------------------------------------------------
 # [include config/hardware/accelerometers/adxl345_rpi.cfg] # For ADXL plugged directly on the Pi (official and recommended way)
 # [include config/hardware/accelerometers/adxl345_usb.cfg] # For KUBSA, ...
+# [include config/hardware/accelerometers/adxl345_usb_rampon.cfg] # For KUBSA with Rampon firmware, ...
 # [include config/hardware/accelerometers/adxl345_skr.cfg] # For ADXL plugged in SKRv1.4 (not a conventional way)
 
 # [include config/hardware/accelerometers/adxl345_sb2040.cfg] # For ADXL plugged in Mellow Fly-SB2040 boards


### PR DESCRIPTION
I've added the config for Rampon firmware for the KUSBA. It uses the recommended setings from the KUSBA github. I've been using it for weeks now and it works fine on my end.