### PR TITLE
Corrected typeof in variable `variable_filter_default_time_on_end_print` configuration

### DIFF
--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -187,7 +187,7 @@ variable_ercf_reset_stats_on_start_print: False
 ################################################
 ## This section is only considered if a filter is available (and enabled)
 
-variable_filter_default_time_on_end_print = 600 # seconds
+variable_filter_default_time_on_end_print: 600 # seconds
 
 ################################################
 # Other hardware options used in the macros


### PR DESCRIPTION
`variables.cfg` incorrectly uses an equal sign (`=`) instead of a colon (`:`) for `variable_filter_default_time_on_end_print`. This has been corrected.