### PR TITLE
Create adxl345_sht_v2.x.cfg

### DIFF
--- a/config/hardware/accelerometers/adxl345_sht_v2.x.cfg
+++ b/config/hardware/accelerometers/adxl345_sht_v2.x.cfg
@@ -1,0 +1,7 @@
+[include generics/adxl345_hardware_spi1.cfg]
+
+# As it's a toolhead ADXL, we add some default pins overrides from here
+[adxl345]
+cs_pin: toolhead:ADXL_CS
+# Supplied config from Mellow is wrong - it states spi1, but at least for a 072 based unit is it on spi2
+spi_bus: spi2 


### PR DESCRIPTION
The SHT36_v2 differs from the SHT36_v1 and has the ADXL345 on SPI2, not SPI1. The Mellow docs are pretty confusing on this!

I'm not sure if this is the right way to go about it, or whether you would prefer to inherit the adxl345_sht.cfg and just override spi_bus?