### PR TITLE
Qgl flash fix

### DIFF
--- a/macros/base/homing/homing_conditional.cfg
+++ b/macros/base/homing/homing_conditional.cfg
@@ -3,14 +3,14 @@ description: Homing only if necessary
 gcode:
     {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
 
-    {% if status_leds_enabled %}
-        STATUS_LEDS COLOR="HOMING"
-    {% endif %}
-
     {% if "xyz" not in printer.toolhead.homed_axes %}
+        {% if status_leds_enabled %}
+            STATUS_LEDS COLOR="HOMING"
+        {% endif %}
         G28
     {% endif %}
 
     {% if status_leds_enabled %}
         STATUS_LEDS COLOR="READY"
-    {% endif %}
+    {% endif %}  
+    


### PR DESCRIPTION
I think I found the issue with the flashing when doing QGL when G28 is not required. To fix it, the lights are only set to homing if a home is really executed.