### PR TITLE
Add RP2040 SPI1 USB boards

### DIFF
--- a/config/hardware/accelerometers/adxl345_usb_rp2040_spi1.cfg
+++ b/config/hardware/accelerometers/adxl345_usb_rp2040_spi1.cfg
@@ -1,0 +1,33 @@
+# This ADXL file is dedicated to be used with USB RP2040 boards where the ADXL
+# is connected to SPI1
+
+# This include FYSTEC PortableInputShaper, ...
+
+
+# You need to set the proper serial in your overrides.cfg file
+[mcu adxl]
+serial: /dev/serial/by-id/xxx
+
+[adxl345]
+cs_pin: adxl:gpio13
+spi_software_sclk_pin: adxl:gpio10
+spi_software_mosi_pin: adxl:gpio11
+spi_software_miso_pin: adxl:gpio12
+axes_map: x,y,z
+# FYSTEC POS: x,-z,y
+
+[resonance_tester]
+accel_chip: adxl345
+probe_points:
+    -1,-1,-1
+# 250mm printers: 125,125,20
+# 300mm printers: 150,150,20
+# 350mm printers: 175,175,20
+
+
+
+# Include the IS calibration macros to unlock them when
+# an accelerometer is installed on the machine
+[include ../../../macros/helpers/resonance_override.cfg]
+[include ../../../macros/calibration/IS_shaper_calibrate.cfg]
+[include ../../../macros/calibration/IS_vibrations_measurement.cfg]


### PR DESCRIPTION
I tried to add my FYSTEC PortableInputShaper board but it uses the SPI1 of the RP2040.
This makes it neccessary to assign all SPI Pins. I guess it's quite the rabbit hole to implement all configs for every board out there but just overriding the adxl345_usb.cfg also doesn't work because it sets a value spi_bus.