### PR TITLE
change string vars declaration to literals

### DIFF
--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -375,7 +375,7 @@ gcode:
     {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
 
     {% if bed_mesh_enabled %}
-        {% if BED_MESH_PROFILE == "" %}
+        {% if BED_MESH_PROFILE == '""'' %}
             {% if status_leds_enabled %}
                 STATUS_LEDS COLOR="MESHING"
             {% endif %}
@@ -383,12 +383,12 @@ gcode:
                 RESPOND MSG="Bed mesh measurement..."
             {% endif %}
 
-            ADAPTIVE_BED_MESH SIZE={FL_SIZE}
+            ADAPTIVE_BED_MESH SIZE='"{FL_SIZE}"'
         {% else %}
             {% if verbose %}
                 RESPOND MSG="Load bed mesh profile : {BED_MESH_PROFILE}"
             {% endif %}
-            BED_MESH_PROFILE LOAD={BED_MESH_PROFILE}
+            BED_MESH_PROFILE LOAD='"{BED_MESH_PROFILE}"'
         {% endif %}
     {% endif %}
 

--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -7,9 +7,9 @@ variable_soak: 0
 variable_chamber_temp: 0
 variable_chamber_maxtime: 0
 variable_initial_tool: 0
-variable_material: "XXX"
-variable_fl_size: "0_0_0_0"
-variable_bed_mesh_profile: ""
+variable_material: '"XXX"'
+variable_fl_size: '"0_0_0_0"'
+variable_bed_mesh_profile: '""'
 gcode:
     # Get all the parameters passed from the slicer
     {% set BED_TEMP = params.BED_TEMP|default(printer["gcode_macro _USER_VARIABLES"].print_default_bed_temp)|float %} # Bed temperature

--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -375,7 +375,7 @@ gcode:
     {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
 
     {% if bed_mesh_enabled %}
-        {% if BED_MESH_PROFILE == '""'' %}
+        {% if BED_MESH_PROFILE == '""' %}
             {% if status_leds_enabled %}
                 STATUS_LEDS COLOR="MESHING"
             {% endif %}


### PR DESCRIPTION
seems that in some instances that empty strings in string var declarations are not recognized correctly. 
Linked to #346 

This is an untested fix, where all var declarations with strings are set as literals. 