### PR TITLE
Correct board_pins to sb2209_mcu

### DIFF
--- a/user_templates/mcu_defaults/toolhead/BTT_SB2209_RP2040_v1.0.cfg
+++ b/user_templates/mcu_defaults/toolhead/BTT_SB2209_RP2040_v1.0.cfg
@@ -13,7 +13,7 @@ canbus_uuid: change-me-to-the-correct-canbus-id
 # in your own overrides.cfg files.
 
 [include config/mcu_definitions/toolhead/BTT_SB2209_RP2040_v1.0.cfg] # Do not remove this line
-[board_pins sb2040can_mcu]
+[board_pins sb2209_mcu]
 mcu: toolhead
 aliases:
     E_STEP=MCU_E0_STEP , E_DIR=MCU_E0_DIR , E_ENABLE=MCU_E0_EN , E_TMCUART=MCU_E0_UART ,


### PR DESCRIPTION
Change board_pins...
From: sb2040can_mcu
To: sb2209_mcu

I originally was going to go with sb2209rp2040, but there's no need to make the alias that long.