### PR TITLE
added templates for BTT MMB board

### DIFF
--- a/config/mcu_definitions/ercf/BTT_MMB_CAN_v1.0.cfg
+++ b/config/mcu_definitions/ercf/BTT_MMB_CAN_v1.0.cfg
@@ -1,0 +1,29 @@
+[board_pins ercf_manufacturer]
+mcu: ercf
+aliases:
+    MCU_MOTOR1_STEP=PB15    , MCU_MOTOR1_DIR=PB14      , MCU_MOTOR1_EN=PA8      , MCU_GEAR_MOTOR1_CS=PA10    ,
+    MCU_MOTOR2_STEP=PD2     , MCU_MOTOR2_DIR=PB13      , MCU_MOTOR2_EN=PD1      , MCU_GEAR_MOTOR2_CS=PC7     ,
+    MCU_MOTOR3_STEP=PD0     , MCU_MOTOR3_DIR=PD3       , MCU_MOTOR3_EN=PA15     , MCU_GEAR_MOTOR3_CS=PC6     ,
+    MCU_MOTOR4_STEP=PB6     , MCU_MOTOR4_DIR=PB7       , MCU_MOTOR4_EN=PB5      , MCU_GEAR_MOTOR4_CS=PA9     ,
+    MCU_SCK=PA5  , MCU_MISO=PA6 , MCU_SPI0_MOSI=PA7 ,
+    MCU_MOTOR3_DIAG=PB9
+
+    # MMB STP definition
+    MCU_STP1=PA3 , # a.u.a. MOTOR1_DIAG
+    MCU_STP2=PA4 , # a.u.a. MOTOR2_DIAG
+    MCU_STP3=PB8 , # a.u.a. MOTOR4_DIAG
+    MCU_STP4=PB7 , 
+    MCU_STP5=PC15 , 
+    MCU_STP6=PC13 , 
+    MCU_STP7=PC14 ,  
+    MCU_STP8=PB12 ,
+    MCU_STP9=PB11 ,
+    MCU_STP10=PB10 ,
+    MCU_STP11=PB2 , 
+    
+    MCU_MOT=PA0 , 
+    MCU_SENSOR=PA1 ,
+    MCU_RGB=PA2 , 
+
+    MCU_I2C_SDA=PB4 , 
+    MCU_I2C_SCL=PB3 , 

--- a/user_templates/mcu_defaults/ercf/BTT_MMB_CAN_v1.0.cfg
+++ b/user_templates/mcu_defaults/ercf/BTT_MMB_CAN_v1.0.cfg
@@ -1,0 +1,31 @@
+
+#---------------------------------------------#
+#### BTT MMB CAN 1.0 MCU definition ###########
+#---------------------------------------------#
+
+[mcu ercf]
+##--------------------------------------------------------------------
+serial: /dev/serial/by-id/change-me-to-the-correct-mcu-path
+# canbus_uuid: change-me-to-the-correct-canbus-id
+##--------------------------------------------------------------------
+
+# If you want to override the wiring of the Fystec ERCF ERB, keep in mind that this
+# board is defined using the "ercf" name. So you should use "pin: ercf:PIN_NAME"
+# in your own overrides.cfg files.
+
+[include config/mcu_definitions/ercf/BTT_MMB_CAN_v1.0.cfg] # Do not remove this line
+[board_pins mcu_ercf]
+mcu: ercf
+aliases:
+    GEAR_STEP=MCU_MOTOR1_STEP         , GEAR_DIR=MCU_MOTOR1_DIR         , GEAR_ENABLE=MCU_MOTOR1_EN         , GEAR_TMCUART=MCU_MOTOR1_CS ,
+    SELECTOR_STEP=MCU_MOTOR2_STEP , SELECTOR_DIR=MCU_MOTOR2_DIR , SELECTOR_ENABLE=MCU_MOTOR2_EN , SELECTOR_TMCUART=MCU_MOTOR2_CS ,
+    SELECTOR_DIAG=MCU_STP2 ,
+
+    GEAR_STOP=MCU_ENDSTOP , SELECTOR_STOP=MCU_ENDSTOP ,
+
+    TOOLHEAD_SENSOR=MCU_STP1 , # double used with MOTOR1_DIAG, so might collide
+    ERCF_SERVO=MCU_MOT            ,
+    ERCF_ENCODER=MCU_SENSOR        ,
+    ERCF_NEOPIXEL=MCU_RGB           ,
+
+

--- a/user_templates/mcu_defaults/ercf/BTT_MMB_CAN_v1.0.cfg
+++ b/user_templates/mcu_defaults/ercf/BTT_MMB_CAN_v1.0.cfg
@@ -9,7 +9,7 @@ serial: /dev/serial/by-id/change-me-to-the-correct-mcu-path
 # canbus_uuid: change-me-to-the-correct-canbus-id
 ##--------------------------------------------------------------------
 
-# If you want to override the wiring of the Fystec ERCF ERB, keep in mind that this
+# If you want to override the wiring of the BTT MMB CAN, keep in mind that this
 # board is defined using the "ercf" name. So you should use "pin: ercf:PIN_NAME"
 # in your own overrides.cfg files.
 


### PR DESCRIPTION
New template for new BTT MMB CAN v1.0

Link:
https://github.com/bigtreetech/MMB

Important, not all pins are shown on the JPG
https://github.com/bigtreetech/MMB/blob/master/Hardware/MMB%20CAN%20V1.0-Pin.jpg?raw=true

I extracted the missing diag pins from the referenced sample config files from the linked repo.

CS and UART are the same pins based on the schematic and the sample config.