### PR TITLE
endstop_phase to enable retriving of stepper positions

### DIFF
--- a/config/machine.cfg
+++ b/config/machine.cfg
@@ -22,6 +22,8 @@ timeout: 1800
 
 [respond]
 
+[endstop_phase]
+
 [force_move]
 enable_force_move: True
 

--- a/config/machine.cfg
+++ b/config/machine.cfg
@@ -22,7 +22,8 @@ timeout: 1800
 
 [respond]
 
-[endstop_phase]
+[endstop_phase stepper_x]
+[endstop_phase stepper_y]
 
 [force_move]
 enable_force_move: True


### PR DESCRIPTION

Based on Kevins post (https://github.com/Klipper3d/klipper/pull/6193#issuecomment-1830952399), it is possible to read stepper positions by merely adding this bare tag into the printer.cfg

Then the mcu position can be retrieved by this variable
`printer.endstop_phase.last_home.stepper_x.mcu_position`