### PR TITLE
Add per material filament sensor switching

### DIFF
--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -46,7 +46,7 @@ gcode:
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
     {% set firmware_retraction_enabled = printer["gcode_macro _USER_VARIABLES"].firmware_retraction_enabled %}
     {% set filter_enabled = printer["gcode_macro _USER_VARIABLES"].filter_enabled %}
-    {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled|default(1) %}
+    {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
 
     {% if MATERIAL not in printer["gcode_macro _USER_VARIABLES"].material_parameters %}
         RESPOND MSG="Material '{MATERIAL}' is unknown!"

--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -46,7 +46,7 @@ gcode:
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
     {% set firmware_retraction_enabled = printer["gcode_macro _USER_VARIABLES"].firmware_retraction_enabled %}
     {% set filter_enabled = printer["gcode_macro _USER_VARIABLES"].filter_enabled %}
-    {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
+    {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled|default(1) %}
 
     {% if MATERIAL not in printer["gcode_macro _USER_VARIABLES"].material_parameters %}
         RESPOND MSG="Material '{MATERIAL}' is unknown!"

--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -46,6 +46,7 @@ gcode:
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
     {% set firmware_retraction_enabled = printer["gcode_macro _USER_VARIABLES"].firmware_retraction_enabled %}
     {% set filter_enabled = printer["gcode_macro _USER_VARIABLES"].filter_enabled %}
+    {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
 
     {% if MATERIAL not in printer["gcode_macro _USER_VARIABLES"].material_parameters %}
         RESPOND MSG="Material '{MATERIAL}' is unknown!"
@@ -151,6 +152,10 @@ gcode:
     SET_GCODE_OFFSET Z_ADJUST={material.additional_z_offset} MOVE=1
     {% if filter_enabled %}
         START_FILTER SPEED={material.filter_speed / 100}
+    {% endif %}
+
+    {% if filament_sensor_enabled and not material.filament_sensor %}
+        SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=0
     {% endif %}
 
     # And.... Goooo!

--- a/macros/helpers/filament_swap.cfg
+++ b/macros/helpers/filament_swap.cfg
@@ -18,6 +18,7 @@ gcode:
 
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
     {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
+    {% set material_filament_sensor = printer["gcode_macro START_PRINT"].material.filament_sensor|default(1) %}
     {% set klippain_ercf_enabled = printer["gcode_macro _USER_VARIABLES"].klippain_ercf_enabled %}
 
     {% if filament_sensor_enabled %}
@@ -52,7 +53,7 @@ gcode:
 
     RESTORE_GCODE_STATE NAME=UNLOAD_FILAMENT_state
 
-    {% if filament_sensor_enabled %}
+    {% if filament_sensor_enabled and material_filament_sensor %}
         SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=1
         {% if verbose %}
             RESPOND MSG="Filament unloaded, runout sensor reactivated"
@@ -79,6 +80,7 @@ gcode:
 
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
     {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
+    {% set material_filament_sensor = printer["gcode_macro START_PRINT"].material.filament_sensor|default(1) %}
     {% set klippain_ercf_enabled = printer["gcode_macro _USER_VARIABLES"].klippain_ercf_enabled %}
 
     {% if filament_sensor_enabled %}
@@ -112,7 +114,7 @@ gcode:
     G92 E0
     RESTORE_GCODE_STATE NAME=LOAD_FILAMENT_state
 
-    {% if filament_sensor_enabled %}
+    {% if filament_sensor_enabled and material_filament_sensor %}
         SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=1
         {% if verbose %}
             RESPOND MSG="Filament loaded, runout sensor reactivated"
@@ -138,6 +140,7 @@ gcode:
 
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
     {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
+    {% set material_filament_sensor = printer["gcode_macro START_PRINT"].material.filament_sensor|default(1) %}
     {% set klippain_ercf_enabled = printer["gcode_macro _USER_VARIABLES"].klippain_ercf_enabled %}
 
     {% if filament_sensor_enabled %}
@@ -182,7 +185,7 @@ gcode:
     
     RESTORE_GCODE_STATE NAME=TIP_SHAPING_state
 
-    {% if filament_sensor_enabled %}
+    {% if filament_sensor_enabled and material_filament_sensor %}
         SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=1
         {% if verbose %}
             RESPOND MSG="Filament tip shaping done, runout sensor reactivated"

--- a/macros/helpers/nozzle_cleaning.cfg
+++ b/macros/helpers/nozzle_cleaning.cfg
@@ -77,6 +77,7 @@ gcode:
     {% set purgeclean_servo_enabled = printer["gcode_macro _USER_VARIABLES"].purgeclean_servo_enabled %}
     {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
     {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
+    {% set material_filament_sensor = printer["gcode_macro START_PRINT"].material.filament_sensor|default(1) %}
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
 
     {% if purge_and_brush_enabled %}
@@ -114,7 +115,7 @@ gcode:
         # No M400 needed here since G4 is also flushing Klipper's buffer
         G4 P{OOZE_TIME * 1000}
 
-        {% if filament_sensor_enabled %}
+        {% if filament_sensor_enabled and material_filament_sensor %}
             SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=1
         {% endif %}
 

--- a/macros/helpers/prime_line.cfg
+++ b/macros/helpers/prime_line.cfg
@@ -15,6 +15,7 @@ gcode:
 
     {% set klippain_ercf_enabled = printer["gcode_macro _USER_VARIABLES"].klippain_ercf_enabled %}
     {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
+    {% set material_filament_sensor = printer["gcode_macro START_PRINT"].material.filament_sensor|default(1) %}
 
     {% set max_extrude_cross_section = printer["configfile"].config["extruder"]["max_extrude_cross_section"]|float %}
     {% set filament_diameter = printer["configfile"].config["extruder"]["filament_diameter"]|float %}
@@ -114,6 +115,6 @@ gcode:
         {% endif %}
     {% endif %}
 
-    {% if filament_sensor_enabled %}
+    {% if filament_sensor_enabled and material_filament_sensor %}
         SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=1
     {% endif %}

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -140,7 +140,7 @@ variable_print_default_material: "XXX"
 
 ## Material configuration parameters applied during START_PRINT by using the slicer MATERIAL variable
 ## FYI, retract paramaters are used only if firmware retraction is enabled, filter speed (in %) is used if
-## there is a filter installed on the machine, etc...
+## there is a filter installed on the machine, filament sensor is on or off if installed, etc...
 ## If you are using another material, just extend the list bellow with a new material and everything should work :)
 variable_material_parameters: {
         'PLA': {
@@ -150,7 +150,8 @@ variable_material_parameters: {
             'retract_speed': 40,
             'unretract_speed': 30,
             'filter_speed': 0,
-            'additional_z_offset': 0
+            'additional_z_offset': 0,
+            'filament_sensor': 1
         },
         'PET': {
             'pressure_advance': 0.0650,
@@ -159,7 +160,8 @@ variable_material_parameters: {
             'retract_speed': 30,
             'unretract_speed': 20,
             'filter_speed': 0,
-            'additional_z_offset': 0.020
+            'additional_z_offset': 0.020,
+            'filament_sensor': 1
         },
         'ABS': {
             'pressure_advance': 0.0480,
@@ -168,7 +170,8 @@ variable_material_parameters: {
             'retract_speed': 40,
             'unretract_speed': 30,
             'filter_speed': 80,
-            'additional_z_offset': 0
+            'additional_z_offset': 0,
+            'filament_sensor': 1
         }
     }
 

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -172,6 +172,16 @@ variable_material_parameters: {
             'filter_speed': 80,
             'additional_z_offset': 0,
             'filament_sensor': 1
+        },
+        'TPU': {
+            'pressure_advance': 0.0500,
+            'retract_length': 0.2,
+            'unretract_extra_length': 0,
+            'retract_speed': 5,
+            'unretract_speed': 5,
+            'filter_speed': 0,
+            'additional_z_offset': 0.040,
+            'filament_sensor': 0
         }
     }
 


### PR DESCRIPTION
Filament sensors, at least my version of the BTT SFS, put too much tension on flexible filaments like TPU so I've found a need to bypass it. This will allow users to enable or disable the sensor easily based on the filament type.