### PR TITLE
Moonraker update check for klippain in Mainsail

### DIFF
--- a/moonraker/base.conf
+++ b/moonraker/base.conf
@@ -38,7 +38,6 @@ enable_auto_refresh: True
 [update_manager Klippain]
 type: git_repo
 path: ~/klippain_config
-channel: beta
 origin: https://github.com/Frix-x/klippain.git
 primary_branch: main
 managed_services: moonraker klipper


### PR DESCRIPTION
I don't know if it's a general issue, but for myself if i use `channel: beta` in moonraker config for `[update_manager Klippain]` it's not possible to have the mainsail update up to date for klippain repo. I use another branch of klippain with `git checkout` so I don't know if main branch users have the same problem?