### PR TITLE
Add support for dockable probes with separate retainer

### DIFF
--- a/macros/base/probing/dockable_probe.cfg
+++ b/macros/base/probing/dockable_probe.cfg
@@ -211,9 +211,8 @@ gcode:
 
     {% set probe_servo_enabled = printer["gcode_macro _USER_VARIABLES"].probe_servo_enabled %}
 
-    # Probe retainer
-    {% set probe_dock_separate_retainer = printer["gcode_macro _USER_VARIABLES"].probe_dock_separate_retainer|default(False) %}
-    {% set probe_dock_retainer_location_z = printer["gcode_macro _USER_VARIABLES"].probe_dock_retainer_location_z|default(5)|float %}
+    # Probe stow height
+    {% set probe_stow_z_height = printer["gcode_macro _USER_VARIABLES"].probe_stow_z_height|default(None) %}
 
 
     _ENTRY_POINT FUNCTION=DOCK_PROBE
@@ -262,9 +261,9 @@ gcode:
         # Move probe into dock
         _PROBE_MOVE_TO LOCATION='dock' SPEED={probe_dock_speed}
 
-        # Drop probe to retainer (if needed)
-        {% if probe_dock_separate_retainer %}
-            G0 Z{probe_dock_retainer_location_z} F{z_drop_speed}
+        # Move probe to stow z height if defined
+        {% if probe_stow_z_height is not none %}
+            G0 Z{probe_stow_z_height} F{z_drop_speed}
         {% endif %}
 
         # Get detach probe

--- a/macros/base/probing/dockable_probe.cfg
+++ b/macros/base/probing/dockable_probe.cfg
@@ -211,6 +211,10 @@ gcode:
 
     {% set probe_servo_enabled = printer["gcode_macro _USER_VARIABLES"].probe_servo_enabled %}
 
+    # Probe retainer
+    {% set probe_dock_separate_retainer = printer["gcode_macro _USER_VARIABLES"].probe_dock_separate_retainer|default(False) %}
+    {% set probe_dock_retainer_location_z = printer["gcode_macro _USER_VARIABLES"].probe_dock_retainer_location_z|default(5)|float %}
+
 
     _ENTRY_POINT FUNCTION=DOCK_PROBE
 
@@ -247,7 +251,7 @@ gcode:
         {% set saved_decel = printer.toolhead.max_accel_to_decel %}
         M204 S{probe_dock_accel}
 
-        # Probe entry location
+        # Move to probe entry location
         _PROBE_MOVE_TO LOCATION={probe_before_dock_position} DISTANCE={probe_move_dock_length} SPEED={travel_speed}
 
         # Deploy dock using the servo (if available)
@@ -255,8 +259,13 @@ gcode:
             _SERVO_DEPLOY ITEM="probe"
         {% endif %}
 
-        # Pickup from Probe location
+        # Move probe into dock
         _PROBE_MOVE_TO LOCATION='dock' SPEED={probe_dock_speed}
+
+        # Drop probe to retainer (if needed)
+        {% if probe_dock_separate_retainer %}
+            G0 Z{probe_dock_retainer_location_z} F{z_drop_speed}
+        {% endif %}
 
         # Get detach probe
         _PROBE_MOVE_TO LOCATION={probe_after_dock_position} DISTANCE={probe_move_dock_length} SPEED={probe_dock_speed}

--- a/macros/base/probing/overides/dockable_probe_overides.cfg
+++ b/macros/base/probing/overides/dockable_probe_overides.cfg
@@ -46,6 +46,10 @@ gcode:
             %}{'%s=%s ' % (p, params[p])}{%
            endfor %}
     
+    # Save nozzle location before dock
+    M400
+    _ENTRY_POINT FUNCTION=PROBE_CALIBRATE
+
     DEACTIVATE_PROBE
 
     # Restore nozzle location again at the end
@@ -94,6 +98,10 @@ gcode:
     _BASE_PROBE_ACCURACY {% for p in params
             %}{'%s=%s ' % (p, params[p])}{%
            endfor %}
+
+    # Save nozzle location before dock
+    M400
+    _ENTRY_POINT FUNCTION=PROBE_CALIBRATE
 
     DEACTIVATE_PROBE
 

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -84,6 +84,10 @@ variable_max_bed_xy: 9999, 9999
 ## Minimum safe Z height to attach/detach probe
 variable_probe_min_z_travel: 20
 
+## If probe dock has a retainer and how far to drop to before detaching 
+variable_probe_dock_separate_retainer: False
+variable_probe_dock_retainer_location_z: 20
+
 ## Position of the probe dock
 variable_probe_dock_location_xy: -1, -1
 

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -84,9 +84,10 @@ variable_max_bed_xy: 9999, 9999
 ## Minimum safe Z height to attach/detach probe
 variable_probe_min_z_travel: 20
 
-## If probe dock has a retainer and how far to drop to before detaching 
-variable_probe_dock_separate_retainer: False
-variable_probe_dock_retainer_location_z: 20
+## Z height to move to when detaching probe
+## Setting to 'None' or removing this variable will prevent any
+## change in z position when detaching the probe 
+variable_probe_stow_z_height: None
 
 ## Position of the probe dock
 variable_probe_dock_location_xy: -1, -1


### PR DESCRIPTION
Adds support for probes like the [KlackEnder probe](https://github.com/kevinakasam/KlackEnder-Probe) which use a retainer separate from the dock when detaching the probe. 