### PR TITLE
Update orbiter2.0.cfg

### DIFF
--- a/config/hardware/extruder/orbiter2.0.cfg
+++ b/config/hardware/extruder/orbiter2.0.cfg
@@ -22,6 +22,9 @@ min_extrude_temp: 172
 pressure_advance: 0.0475
 pressure_advance_smooth_time: 0.040
 
+# Orbiter 2 motor will not be happy with 0.45 for run current. Recommended value in overrides.cfg is 0.85 depending on driver. 
+# https://www.orbiterprojects.com/orbiter-v2-0/ for more details
+
 # We also include the default wiring and low thermal hotend patch
 [include default_wiring.cfg]
 [include ../../../macros/helpers/hotend_heater_ctrl.cfg]


### PR DESCRIPTION
Add comment about required current. At the default of 0.45 on the Orbiter 2 motor, very poor performance will occur including significant underextrusion on infill, etc.