### PR TITLE
Add missing variable to cancel_print

### DIFF
--- a/macros/base/cancel_print.cfg
+++ b/macros/base/cancel_print.cfg
@@ -4,6 +4,7 @@ description: Cancel the print, retract 10mm of filament and park
 gcode:
     {% set turn_off_heaters_in_end_print = printer["gcode_macro _USER_VARIABLES"].turn_off_heaters_in_end_print %}
     {% set safe_extruder_temp = printer["gcode_macro _USER_VARIABLES"].safe_extruder_temp|float %}
+    {% set light_intensity_end_print = printer["gcode_macro _USER_VARIABLES"].light_intensity_end_print %}
     {% set klippain_ercf_enabled = printer["gcode_macro _USER_VARIABLES"].klippain_ercf_enabled %}
     {% set ercf_unload_on_cancel_print = printer["gcode_macro _USER_VARIABLES"].ercf_unload_on_cancel_print %}
     {% set filter_enabled = printer["gcode_macro _USER_VARIABLES"].filter_enabled %}


### PR DESCRIPTION
`light_intensity_end_print` is used in this macro, but the variable was never defined and set.