### PR TITLE
Make filament sensor status checks universal

### DIFF
--- a/macros/base/cancel_print.cfg
+++ b/macros/base/cancel_print.cfg
@@ -10,6 +10,7 @@ gcode:
     {% set light_enabled = printer["gcode_macro _USER_VARIABLES"].light_enabled %}
     {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
+    {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
 
     PARK
 
@@ -52,4 +53,9 @@ gcode:
         STATUS_LEDS COLOR="OFF"
     {% endif %}
 
+    # If a filament sensor is connected, re-enable it in case it was disabled during printing
+    {% if filament_sensor_enabled %}
+        SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=1
+    {% endif %}
+    
     BASE_CANCEL_PRINT

--- a/macros/base/end_print.cfg
+++ b/macros/base/end_print.cfg
@@ -12,7 +12,6 @@ gcode:
     {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
     {% set filter_default_time = printer["gcode_macro _USER_VARIABLES"].filter_default_time_on_end_print|default(600)|int %}
-    {% set filter_speed = printer["gcode_macro START_PRINT"].material.filter_speed|default(0)|int %}
     {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
 
     PARK

--- a/macros/base/end_print.cfg
+++ b/macros/base/end_print.cfg
@@ -13,6 +13,7 @@ gcode:
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
     {% set filter_default_time = printer["gcode_macro _USER_VARIABLES"].filter_default_time_on_end_print|default(600)|int %}
     {% set filter_speed = printer["gcode_macro START_PRINT"].material.filter_speed|default(0)|int %}
+    {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
 
     PARK
 
@@ -58,4 +59,9 @@ gcode:
     {% endif %}
     {% if status_leds_enabled %}
         STATUS_LEDS COLOR="OFF"
+    {% endif %}
+
+    # If a filament sensor is connected, re-enable it in case it was disabled during printing
+    {% if filament_sensor_enabled %}
+        SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=1
     {% endif %}

--- a/macros/helpers/filament_swap.cfg
+++ b/macros/helpers/filament_swap.cfg
@@ -18,13 +18,16 @@ gcode:
 
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
     {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
-    {% set material_filament_sensor = printer["gcode_macro START_PRINT"].material.filament_sensor|default(1) %}
+    {% set re_enable_filament_sensor = 0 %}
     {% set klippain_ercf_enabled = printer["gcode_macro _USER_VARIABLES"].klippain_ercf_enabled %}
 
     {% if filament_sensor_enabled %}
-        SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=0
-        {% if verbose %}
-            RESPOND MSG="Runout sensor deactivated to unload filament"
+        {% if printer['filament_motion_sensor runout_sensor'].enabled or printer['filament_switch_sensor runout_sensor'].enabled %}
+            SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=0
+            {% set re_enable_filament_sensor = 1 %}
+            {% if verbose %}
+                RESPOND MSG="Runout sensor deactivated to unload filament"
+            {% endif %}
         {% endif %}
     {% endif %}
 
@@ -53,7 +56,7 @@ gcode:
 
     RESTORE_GCODE_STATE NAME=UNLOAD_FILAMENT_state
 
-    {% if filament_sensor_enabled and material_filament_sensor %}
+    {% if filament_sensor_enabled and re_enable_filament_sensor %}
         SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=1
         {% if verbose %}
             RESPOND MSG="Filament unloaded, runout sensor reactivated"
@@ -80,13 +83,16 @@ gcode:
 
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
     {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
-    {% set material_filament_sensor = printer["gcode_macro START_PRINT"].material.filament_sensor|default(1) %}
     {% set klippain_ercf_enabled = printer["gcode_macro _USER_VARIABLES"].klippain_ercf_enabled %}
+    {% set re_enable_filament_sensor = 0 %}
 
     {% if filament_sensor_enabled %}
-        SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=0
-        {% if verbose %}
-            RESPOND MSG="Runout sensor deactivated to load filament"
+        {% if printer['filament_motion_sensor runout_sensor'].enabled or printer['filament_switch_sensor runout_sensor'].enabled %}
+            SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=0
+            {% set re_enable_filament_sensor = 1 %}
+            {% if verbose %}
+                RESPOND MSG="Runout sensor deactivated to load filament"
+            {% endif %}
         {% endif %}
     {% endif %}
 
@@ -114,7 +120,7 @@ gcode:
     G92 E0
     RESTORE_GCODE_STATE NAME=LOAD_FILAMENT_state
 
-    {% if filament_sensor_enabled and material_filament_sensor %}
+    {% if filament_sensor_enabled and re_enable_filament_sensor %}
         SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=1
         {% if verbose %}
             RESPOND MSG="Filament loaded, runout sensor reactivated"
@@ -140,13 +146,16 @@ gcode:
 
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
     {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
-    {% set material_filament_sensor = printer["gcode_macro START_PRINT"].material.filament_sensor|default(1) %}
     {% set klippain_ercf_enabled = printer["gcode_macro _USER_VARIABLES"].klippain_ercf_enabled %}
+    {% set re_enable_filament_sensor = 0 %}
 
     {% if filament_sensor_enabled %}
-        SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=0
-        {% if verbose %}
-            RESPOND MSG="Runout sensor deactivated for filament tip shaping"
+        {% if printer['filament_motion_sensor runout_sensor'].enabled or printer['filament_switch_sensor runout_sensor'].enabled %}
+            SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=0
+            {% set re_enable_filament_sensor = 1 %}
+            {% if verbose %}
+                RESPOND MSG="Runout sensor deactivated for filament tip shaping"
+            {% endif %}
         {% endif %}
     {% endif %}
 
@@ -185,7 +194,7 @@ gcode:
     
     RESTORE_GCODE_STATE NAME=TIP_SHAPING_state
 
-    {% if filament_sensor_enabled and material_filament_sensor %}
+    {% if filament_sensor_enabled and re_enable_filament_sensor %}
         SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=1
         {% if verbose %}
             RESPOND MSG="Filament tip shaping done, runout sensor reactivated"

--- a/macros/helpers/filament_swap.cfg
+++ b/macros/helpers/filament_swap.cfg
@@ -22,7 +22,7 @@ gcode:
     {% set klippain_ercf_enabled = printer["gcode_macro _USER_VARIABLES"].klippain_ercf_enabled %}
 
     {% if filament_sensor_enabled %}
-        {% if printer['filament_motion_sensor runout_sensor'].enabled or printer['filament_switch_sensor runout_sensor'].enabled %}
+        {% if (printer['filament_motion_sensor runout_sensor'] is defined and printer['filament_motion_sensor runout_sensor'].enabled) or (printer['filament_switch_sensor runout_sensor'] is defined and printer['filament_switch_sensor runout_sensor'].enabled) %}
             SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=0
             {% set re_enable_filament_sensor = 1 %}
             {% if verbose %}
@@ -87,7 +87,7 @@ gcode:
     {% set re_enable_filament_sensor = 0 %}
 
     {% if filament_sensor_enabled %}
-        {% if printer['filament_motion_sensor runout_sensor'].enabled or printer['filament_switch_sensor runout_sensor'].enabled %}
+        {% if (printer['filament_motion_sensor runout_sensor'] is defined and printer['filament_motion_sensor runout_sensor'].enabled) or (printer['filament_switch_sensor runout_sensor'] is defined and printer['filament_switch_sensor runout_sensor'].enabled) %}
             SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=0
             {% set re_enable_filament_sensor = 1 %}
             {% if verbose %}
@@ -150,7 +150,7 @@ gcode:
     {% set re_enable_filament_sensor = 0 %}
 
     {% if filament_sensor_enabled %}
-        {% if printer['filament_motion_sensor runout_sensor'].enabled or printer['filament_switch_sensor runout_sensor'].enabled %}
+        {% if (printer['filament_motion_sensor runout_sensor'] is defined and printer['filament_motion_sensor runout_sensor'].enabled) or (printer['filament_switch_sensor runout_sensor'] is defined and printer['filament_switch_sensor runout_sensor'].enabled) %}
             SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=0
             {% set re_enable_filament_sensor = 1 %}
             {% if verbose %}

--- a/macros/helpers/nozzle_cleaning.cfg
+++ b/macros/helpers/nozzle_cleaning.cfg
@@ -93,7 +93,7 @@ gcode:
         {% endif %}
 
         {% if filament_sensor_enabled %}
-            {% if printer['filament_motion_sensor runout_sensor'].enabled or printer['filament_switch_sensor runout_sensor'].enabled %}
+            {% if (printer['filament_motion_sensor runout_sensor'] is defined and printer['filament_motion_sensor runout_sensor'].enabled) or (printer['filament_switch_sensor runout_sensor'] is defined and printer['filament_switch_sensor runout_sensor'].enabled) %}
                 SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=0
                 {% set re_enable_filament_sensor = 1 %}
             {% endif %}

--- a/macros/helpers/nozzle_cleaning.cfg
+++ b/macros/helpers/nozzle_cleaning.cfg
@@ -77,7 +77,7 @@ gcode:
     {% set purgeclean_servo_enabled = printer["gcode_macro _USER_VARIABLES"].purgeclean_servo_enabled %}
     {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
     {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
-    {% set material_filament_sensor = printer["gcode_macro START_PRINT"].material.filament_sensor|default(1) %}
+    {% set re_enable_filament_sensor = 0 %}
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
 
     {% if purge_and_brush_enabled %}
@@ -93,7 +93,10 @@ gcode:
         {% endif %}
 
         {% if filament_sensor_enabled %}
-            SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=0
+            {% if printer['filament_motion_sensor runout_sensor'].enabled or printer['filament_switch_sensor runout_sensor'].enabled %}
+                SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=0
+                {% set re_enable_filament_sensor = 1 %}
+            {% endif %}
         {% endif %}
 
         G90
@@ -115,7 +118,7 @@ gcode:
         # No M400 needed here since G4 is also flushing Klipper's buffer
         G4 P{OOZE_TIME * 1000}
 
-        {% if filament_sensor_enabled and material_filament_sensor %}
+        {% if filament_sensor_enabled and re_enable_filament_sensor %}
             SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=1
         {% endif %}
 

--- a/macros/helpers/prime_line.cfg
+++ b/macros/helpers/prime_line.cfg
@@ -15,7 +15,7 @@ gcode:
 
     {% set klippain_ercf_enabled = printer["gcode_macro _USER_VARIABLES"].klippain_ercf_enabled %}
     {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
-    {% set material_filament_sensor = printer["gcode_macro START_PRINT"].material.filament_sensor|default(1) %}
+    {% set re_enable_filament_sensor = 0 %}
 
     {% set max_extrude_cross_section = printer["configfile"].config["extruder"]["max_extrude_cross_section"]|float %}
     {% set filament_diameter = printer["configfile"].config["extruder"]["filament_diameter"]|float %}
@@ -67,7 +67,10 @@ gcode:
     {% endif %}
 
     {% if filament_sensor_enabled %}
-        SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=0
+        {% if printer['filament_motion_sensor runout_sensor'].enabled or printer['filament_switch_sensor runout_sensor'].enabled %}
+            SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=0
+            {% set re_enable_filament_sensor = 1 %}
+        {% endif %}
     {% endif %}
 
     G91
@@ -115,6 +118,6 @@ gcode:
         {% endif %}
     {% endif %}
 
-    {% if filament_sensor_enabled and material_filament_sensor %}
+    {% if filament_sensor_enabled and re_enable_filament_sensor %}
         SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=1
     {% endif %}

--- a/macros/helpers/prime_line.cfg
+++ b/macros/helpers/prime_line.cfg
@@ -67,7 +67,7 @@ gcode:
     {% endif %}
 
     {% if filament_sensor_enabled %}
-        {% if printer['filament_motion_sensor runout_sensor'].enabled or printer['filament_switch_sensor runout_sensor'].enabled %}
+        {% if (printer['filament_motion_sensor runout_sensor'] is defined and printer['filament_motion_sensor runout_sensor'].enabled) or (printer['filament_switch_sensor runout_sensor'] is defined and printer['filament_switch_sensor runout_sensor'].enabled) %}
             SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=0
             {% set re_enable_filament_sensor = 1 %}
         {% endif %}


### PR DESCRIPTION
Change the way the status of the filament sensor is checked so it won't be re-enabled if it was previously disabled by a macro or manually. Also add code to re-enable the sensor in the end_print and cancel_print macros.

After giving some thought about [this](https://github.com/Frix-x/klippain/pull/381#issuecomment-1853590423) comment I agree that it's a better way to universally check the status of the filament sensor prior to making any change to its state.

I've tested this in the purge routine and if the sensor was disabled before the macro was called it remains disabled after completion, and vice-versa.