### PR TITLE
added spoolman support

### DIFF
--- a/config/software/spoolman.cfg
+++ b/config/software/spoolman.cfg
@@ -1,0 +1,23 @@
+[gcode_macro _USER_VARIABLES]
+variable_spoolman_enabled: True
+gcode:
+
+[gcode_macro SET_ACTIVE_SPOOL]
+gcode:
+  {% if params.ID %}
+    {% set id = params.ID|int %}
+    {action_call_remote_method(
+       "spoolman_set_active_spool",
+       spool_id=id
+    )}
+  {% else %}
+    {action_respond_info("Parameter 'ID' is required")}
+  {% endif %}
+
+[gcode_macro CLEAR_ACTIVE_SPOOL]
+gcode:
+  {action_call_remote_method(
+    "spoolman_set_active_spool",
+    spool_id=None
+  )}
+  

--- a/moonraker/spoolman.conf
+++ b/moonraker/spoolman.conf
@@ -1,0 +1,8 @@
+# this is a default configuration pointing the default installation on the printer itself
+# you can set an own config by excluding this file, copy its content in moonraker.conf and change the values
+[spoolman]
+server: http://localhost:7912
+#   URL to the Spoolman instance. This parameter must be provided.
+sync_rate: 5
+#   The interval, in seconds, between sync requests with the
+#   Spoolman server.  The default is 5.

--- a/user_templates/moonraker.conf
+++ b/user_templates/moonraker.conf
@@ -31,6 +31,9 @@
 # [include moonraker/z_calibration.conf]
 # -----------------------------------------------------------------
 
+##### Spoolman configuration file  -----------------
+# [include moonraker/spoolman.conf]
+# -----------------------------------------------------------------
 
 ##### Add your custom moonraker config customizations and overrides below this line...
 # ------------------------------------------------------------------------------------

--- a/user_templates/printer.cfg
+++ b/user_templates/printer.cfg
@@ -270,6 +270,14 @@
 # ----------------------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------- SPOOLMAN ----
+### --------------------------------------------------------------------------------------
+### This software can be used to create an inventory of spools and the calculated remaining amount based on gcode information
+### To use the software, it must be installed from here: https://github.com/Donkie/Spoolman
+### also don't forget to uncomment the spoolman line in moonraker.conf to be able to integrate Spoolman in moonraker
+# [include config/software/spoolman.cfg]
+# ----------------------------------------------------------------------------------------
+
 
 ###################################
 ### DO NOT EDIT BELOW THIS LINE ###


### PR DESCRIPTION
I added spoolman integration to klippain.

Source: https://github.com/Donkie/Spoolman

I tried using the configuration with the provided default settings (in my case i went with docker installation on the pi) It works with localhost to point to itself in browsing the spoolman webinterface and the integration in mainsail.