### PR TITLE
add retract in park macro

### DIFF
--- a/macros/base/park.cfg
+++ b/macros/base/park.cfg
@@ -28,11 +28,17 @@ gcode:
     {% else %}      # retract filament before move up toolhead
         {% if printer.extruder.can_extrude %}
             {% if firmware_retraction_enabled %}    # use firmware_retraction parameter for retract (in case firmware retraction is selected in printer.cfg)
+                {% if verbose %}
+                    RESPOND MSG="Firmware retraction enabled, Extruder retraction = {printer.firmware_retraction.retract_length}"
+                {% endif %}
                 G10
             {% else %}                              # otherwise:
                 {% if MATERIAL != "XXX" %}          # use material parameter if available for retract, otherwise use default value
                     {% set material = printer["gcode_macro _USER_VARIABLES"].material_parameters[MATERIAL] %}
                     {% set E = material.retract_length %}
+                {% endif %}
+                {% if verbose %}
+                    RESPOND MSG="Firmware retraction disabled, Extruder retraction = {E}"
                 {% endif %}
                 G92 E0
                 G1 E-{E} F2100

--- a/macros/base/park.cfg
+++ b/macros/base/park.cfg
@@ -2,9 +2,9 @@
 description: Park the toolhead at the back and retract some filament if the nozzle is hot
 gcode:
     {% set E = params.E|default(1.7)|float %}
+    {% set MATERIAL = printer['gcode_macro START_PRINT'].material %}
 
     {% set Px, Py = printer["gcode_macro _USER_VARIABLES"].park_position_xy|map('float') %}
-    
     {% set Px = params.X|default(Px)|float %}
     {% set Py = params.Y|default(Py)|float %}
     
@@ -22,11 +22,24 @@ gcode:
         {% set z_safe = max_z %}
     {% endif %}
 
-    # retract filament before move up toolhead
-    {% if printer.extruder.temperature > 185 and firmware_retraction_enabled %}
-        G10
+    {% if printer.toolhead.homed_axes != "xyz" %}
+        RESPOND MSG="Cannot park because XYZ not homed"
+    {% else %}      # retract filament before move up toolhead
+        {% if printer.extruder.can_extrude %}
+            {% if firmware_retraction_enabled %}    # use firmware_retraction parameter for retract (in case firmware retraction is selected in printer.cfg)
+                G10
+            {% else %}                              # otherwise:
+                {% if MATERIAL != "XXX" %}          # use material parameter if available for retract, otherwise use default value
+                    {% set material = printer["gcode_macro _USER_VARIABLES"].material_parameters[MATERIAL] %}
+                    {% set E = material.retract_length %}
+                {% endif %}
+                G92 E0
+                G1 E-{E} F2100
+            {% endif %}
+        {% else %}
+            RESPOND MSG="no extruder retraction because extruder temperature ({printer.extruder.temperature}) is lower than min_extrude_temp ({printer.configfile.config.extruder.min_extrude_temp})"
+        {% endif %}
+        G90
+        G1 Z{z_safe} F{Sz}
+        G0 X{Px} Y{Py} F{St}
     {% endif %}
-    G90
-    G1 Z{z_safe} F{Sz}
-
-    G0 X{Px} Y{Py} F{St}

--- a/macros/base/park.cfg
+++ b/macros/base/park.cfg
@@ -9,6 +9,7 @@ gcode:
     {% set Py = params.Y|default(Py)|float %}
     
     {% set park_lift_z = printer["gcode_macro _USER_VARIABLES"].park_lift_z %}
+    {% set Z_HOP = params.Z_HOP|default(park_lift_z)|float %}
     {% set firmware_retraction_enabled = printer["gcode_macro _USER_VARIABLES"].firmware_retraction_enabled %}
 
     {% set St = printer["gcode_macro _USER_VARIABLES"].travel_speed * 60 %}
@@ -17,7 +18,7 @@ gcode:
     {% set max_z = printer.toolhead.axis_maximum.z|float %}
     {% set act_z = printer.toolhead.position.z|float %}
 
-    {% set z_safe = act_z + park_lift_z %}
+    {% set z_safe = act_z + Z_HOP %}
     {% if z_safe > max_z %}
         {% set z_safe = max_z %}
     {% endif %}
@@ -39,9 +40,7 @@ gcode:
         {% else %}
             RESPOND MSG="no extruder retraction because extruder temperature ({printer.extruder.temperature}) is lower than min_extrude_temp ({printer.configfile.config.extruder.min_extrude_temp})"
         {% endif %}
-        SAVE_GCODE_STATE NAME=PARK
         G90
         G1 Z{z_safe} F{Sz}
         G0 X{Px} Y{Py} F{St}
-        RESTORE_GCODE_STATE NAME=PARK
     {% endif %}

--- a/macros/base/park.cfg
+++ b/macros/base/park.cfg
@@ -39,7 +39,9 @@ gcode:
         {% else %}
             RESPOND MSG="no extruder retraction because extruder temperature ({printer.extruder.temperature}) is lower than min_extrude_temp ({printer.configfile.config.extruder.min_extrude_temp})"
         {% endif %}
+        SAVE_GCODE_STATE NAME=PARK
         G90
         G1 Z{z_safe} F{Sz}
         G0 X{Px} Y{Py} F{St}
+        RESTORE_GCODE_STATE NAME=PARK
     {% endif %}


### PR DESCRIPTION
In curent park macro the retraction of filament is only possible when firmware_retraction is included in printer.cfg. Otherwise there is no retraction.
This PR try to add some filament retraction in case of firmware retraction isn't enabeled in printer.cfg by using the curent material parse by start_print or the default (E) value already existing in park macro.