### PR TITLE
Add Fysetc mini12864 v1.2 and v2.0

### DIFF
--- a/config/hardware/displays/Fysetc_mini12864_v1.2_v2.0.cfg
+++ b/config/hardware/displays/Fysetc_mini12864_v1.2_v2.0.cfg
@@ -1,0 +1,35 @@
+# Neopixel leds integrated in the Fysetc mini12864 display
+[gcode_macro _USER_VARIABLES]
+variable_status_leds_minidisplay_enabled = True
+variable_status_leds_minidisplay_led_name: "fysetc_mini12864"
+gcode:
+
+# Also include directly the leds control macros from here
+[include ../../../macros/hardware_functions/status_leds.cfg]
+
+
+[display]
+lcd_type: uc1701
+cs_pin: EXP1_8
+a0_pin: EXP1_7
+rst_pin: EXP1_6
+encoder_pins: ^EXP2_8, ^EXP2_6
+click_pin: ^!EXP1_9
+## Some micro-controller boards may require an spi bus to be specified:
+#spi_bus: spi
+## Alternatively, some micro-controller boards may work with software spi:
+contrast: 63
+spi_software_miso_pin: EXP2_10
+spi_software_mosi_pin: EXP2_5
+spi_software_sclk_pin: EXP2_9
+
+[output_pin beeper]
+pin: EXP1_10
+
+[led fysetc_mini12864]
+red_pin: EXP1_5
+green_pin: EXP1_4
+blue_pin: EXP1_3
+initial_RED: 0.1
+initial_GREEN: 0.5
+initial_BLUE: 0.0

--- a/config/hardware/displays/Fysetc_mini12864_v1.2_v2.0_inversed.cfg
+++ b/config/hardware/displays/Fysetc_mini12864_v1.2_v2.0_inversed.cfg
@@ -1,0 +1,35 @@
+# Neopixel leds integrated in the Fysetc mini12864 display
+[gcode_macro _USER_VARIABLES]
+variable_status_leds_minidisplay_enabled = True
+variable_status_leds_minidisplay_led_name: "fysetc_mini12864"
+gcode:
+
+# Also include directly the leds control macros from here
+[include ../../../macros/hardware_functions/status_leds.cfg]
+
+
+[display]
+lcd_type: uc1701
+cs_pin: EXP1_3
+a0_pin: EXP1_4
+rst_pin: EXP1_5
+encoder_pins: ^EXP2_3, ^EXP2_5
+click_pin: ^!EXP1_2
+## Some micro-controller boards may require an spi bus to be specified:
+#spi_bus: spi
+## Alternatively, some micro-controller boards may work with software spi:
+contrast: 63
+spi_software_miso_pin: EXP2_1
+spi_software_mosi_pin: EXP2_6
+spi_software_sclk_pin: EXP2_2
+
+[output_pin beeper]
+pin: EXP1_1
+
+[led fysetc_mini12864]
+red_pin: EXP1_6
+green_pin: EXP1_7
+blue_pin: EXP1_8
+initial_RED: 0.1
+initial_GREEN: 0.5
+initial_BLUE: 0.0

--- a/user_templates/printer.cfg
+++ b/user_templates/printer.cfg
@@ -128,6 +128,7 @@
 ### that correspond to your display brand in the following lines:
 # [include config/hardware/displays/BTT_mini12864.cfg]
 # [include config/hardware/displays/Fysetc_mini12864.cfg]
+# [include config/hardware/displays/Fysetc_mini12864_v1.2_v2.0.cfg]
 
 ### As BTT and Fysetc have done the wiring exactly the opposite on their boards, if you are mixing
 ### the brands (ie. a BTT display on a Fysetc board, or the opposite), please use the file
@@ -135,6 +136,7 @@
 ### rotate connectors 180 degree according to this documentation: https://docs.vorondesign.com/build/electrical/mini12864_klipper_guide.html
 # [include config/hardware/displays/BTT_mini12864_inversed.cfg]
 # [include config/hardware/displays/Fysetc_mini12864_inversed.cfg]
+# [include config/hardware/displays/Fysetc_mini12864_v1.2_v2.0_inversed.cfg]
 # ----------------------------------------------------------------------------------------
 
 


### PR DESCRIPTION
For these two version, only the RGB is different from the V2.1 already included in klippain. They're using 3 separate pins for red, green, and blue instead of neopixel.
V1.2 only the knob is RGB, screen color is fixed
V2.0 screen and knob are RGB