### PR TITLE
BTT S2DW V1.0 and similar RP2040 + lis2dw boards

### DIFF
--- a/config/hardware/accelerometers/lis2dw_usb_rp2040_spi1.cfg
+++ b/config/hardware/accelerometers/lis2dw_usb_rp2040_spi1.cfg
@@ -1,0 +1,26 @@
+# This LIS2DW file is dedicated to be used with USB RP2040 boards where the LIS2DW
+# is connected to SPI1
+
+# This include BTT S2DW V1.0, ...
+
+
+# You need to set the proper serial in your overrides.cfg file
+[mcu lis2dw_mcu]
+serial: /dev/serial/by-id/xxx
+
+[lis2dw]
+cs_pin: lis2dw_mcu:gpio9
+spi_bus: spi1a
+axes_map: -y,x,-z
+
+[resonance_tester]
+accel_chip: lis2dw
+probe_points:
+    -1,-1,-1
+
+
+# Include the IS calibration macros to unlock them when
+# an accelerometer is installed on the machine
+[include ../../../macros/helpers/resonance_override.cfg]
+[include ../../../macros/calibration/IS_shaper_calibrate.cfg]
+[include ../../../macros/calibration/IS_vibrations_measurement.cfg]

--- a/user_templates/printer.cfg
+++ b/user_templates/printer.cfg
@@ -179,7 +179,7 @@
 # [include config/hardware/accelerometers/adxl345_sht.cfg] # For ADXL plugged in Mellow SHT36 or SHT42 boards
 # [include config/hardware/accelerometers/adxl345_BTT_SB22xx.cfg] # For ADXL plugged in BTT SB2209 or SB2240 boards
 
-# [include config/hardware/accelerometers/adxl345_usb_rp2040_spi1.cfg] # For BTT S2DW V1.0, ... 
+# [include config/hardware/accelerometers/lis2dw_usb_rp2040_spi1.cfg] # For BTT S2DW V1.0, ... 
 # ----------------------------------------------------------------------------------------
 
 

--- a/user_templates/printer.cfg
+++ b/user_templates/printer.cfg
@@ -178,6 +178,8 @@
 # [include config/hardware/accelerometers/adxl345_ebb.cfg] # For ADXL plugged in BTT EBB36 or EBB42 boards
 # [include config/hardware/accelerometers/adxl345_sht.cfg] # For ADXL plugged in Mellow SHT36 or SHT42 boards
 # [include config/hardware/accelerometers/adxl345_BTT_SB22xx.cfg] # For ADXL plugged in BTT SB2209 or SB2240 boards
+
+# [include config/hardware/accelerometers/adxl345_usb_rp2040_spi1.cfg] # For BTT S2DW V1.0, ... 
 # ----------------------------------------------------------------------------------------
 
 


### PR DESCRIPTION
This pull request adds support for the BTT S2DW V1.0 and similar boards where a lis2dw accelerometer is associated to an RP2040 by SPI1. 
