### PR TITLE
Add Octopus Pro 1.0 MCU User Template

### DIFF
--- a/user_templates/mcu_defaults/main/BTT_Octopus_Pro_v1.0.cfg
+++ b/user_templates/mcu_defaults/main/BTT_Octopus_Pro_v1.0.cfg
@@ -1,0 +1,53 @@
+
+#--------------------------------------#
+#### BTT Octopus MCU definition ########
+#--------------------------------------#
+
+[mcu]
+##--------------------------------------------------------------------
+# This board work by using a serial connection by default. If you
+# want to use CAN, invert the commented lines and use canbus_uuid.
+
+serial: /dev/serial/by-id/change-me-to-the-correct-mcu-path
+# canbus_uuid: change-me-to-the-correct-canbus-id
+##--------------------------------------------------------------------
+
+[include config/mcu_definitions/main/BTT_Octopus.cfg] # Do not remove this line
+[board_pins octopus_mcu]
+mcu: mcu
+aliases:
+    X_STEP=MCU_MOTOR0_STEP   , X_DIR=MCU_MOTOR0_DIR   , X_ENABLE=MCU_MOTOR0_ENABLE   , X_TMCUART=MCU_MOTOR0_UART   ,
+    Y_STEP=MCU_MOTOR1_STEP   , Y_DIR=MCU_MOTOR1_DIR   , Y_ENABLE=MCU_MOTOR1_ENABLE   , Y_TMCUART=MCU_MOTOR1_UART   ,
+
+    Z_STEP=MCU_MOTOR2_1_STEP , Z_DIR=MCU_MOTOR2_1_DIR , Z_ENABLE=MCU_MOTOR2_1_ENABLE , Z_TMCUART=MCU_MOTOR2_1_UART ,
+    Z1_STEP=MCU_MOTOR3_STEP  , Z1_DIR=MCU_MOTOR3_DIR  , Z1_ENABLE=MCU_MOTOR3_ENABLE  , Z1_TMCUART=MCU_MOTOR3_UART  ,
+    Z2_STEP=MCU_MOTOR4_STEP  , Z2_DIR=MCU_MOTOR4_DIR  , Z2_ENABLE=MCU_MOTOR4_ENABLE  , Z2_TMCUART=MCU_MOTOR4_UART  ,
+    Z3_STEP=MCU_MOTOR5_STEP  , Z3_DIR=MCU_MOTOR5_DIR  , Z3_ENABLE=MCU_MOTOR5_ENABLE  , Z3_TMCUART=MCU_MOTOR5_UART  ,
+
+    E_STEP=MCU_MOTOR6_STEP   , E_DIR=MCU_MOTOR6_DIR   , E_ENABLE=MCU_MOTOR6_ENABLE   , E_TMCUART=MCU_MOTOR6_UART   ,
+
+    # DRIVER_SPI_MOSI=EXP2_6 , # Used in case of SPI drivers such as TMC2240 or TMC5160
+    # DRIVER_SPI_MISO=EXP2_1 , # Used in case of SPI drivers such as TMC2240 or TMC5160
+    # DRIVER_SPI_SCK=EXP2_2  , # Used in case of SPI drivers such as TMC2240 or TMC5160
+
+    X_STOP=MCU_STOP0 , Y_STOP=MCU_STOP1 , Z_STOP=MCU_STOP2 ,
+    PROBE_INPUT=MCU_STOP7  ,
+    RUNOUT_SENSOR=MCU_STOP3 ,
+
+    E_HEATER=MCU_HE0   , E_TEMPERATURE=MCU_T0   ,
+    BED_HEATER=MCU_HE1 , BED_TEMPERATURE=MCU_TB ,
+
+    PART_FAN=MCU_FAN0 , E_FAN=MCU_FAN1 ,
+    CONTROLLER_FAN=MCU_FAN2        ,
+    EXHAUST_FAN=MCU_FAN3           ,
+    FILTER_FAN=MCU_FAN4            ,
+    HOST_CONTROLLER_FAN=MCU_FAN5   ,
+
+    CHAMBER_TEMPERATURE=MCU_T1 , ELECTRICAL_CABINET_TEMPERATURE=MCU_T2 ,
+
+    LIGHT_OUTPUT=MCU_HE2         ,
+    LIGHT_NEOPIXEL=MCU_STOP5     ,
+    STATUS_NEOPIXEL=MCU_NEOPIXEL ,
+
+    SERVO_PIN=MCU_SERVOS ,
+


### PR DESCRIPTION
Even though the BTT Octopus and BTT Octopus Pro v1.0 have the same pinout, it can be confusing when setting things up. This will add a BTT Octopus Pro v1.0 user template while still referencing the BTT Octopus manufacturer definition.

Closes Issue #440.