### PR TITLE
Add Feature absolute extrusion mode selection

### DIFF
--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -46,6 +46,7 @@ gcode:
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
     {% set firmware_retraction_enabled = printer["gcode_macro _USER_VARIABLES"].firmware_retraction_enabled %}
     {% set filter_enabled = printer["gcode_macro _USER_VARIABLES"].filter_enabled %}
+    {% set extrusion_absolute_mode = (printer["gcode_macro _USER_VARIABLES"].extrusion_absolute_mode|default(false)) %}
 
     {% if MATERIAL not in printer["gcode_macro _USER_VARIABLES"].material_parameters %}
         RESPOND MSG="Material '{MATERIAL}' is unknown!"
@@ -93,7 +94,13 @@ gcode:
     M221 S100
     M220 S100
     G90
-    M83
+    {% if extrusion_absolute_mode %}
+        RESPOND MSG="Setting Absolute Extrusion Mode"
+        M82
+    {% else %}
+        RESPOND MSG="Setting Relative Extrusion Mode"
+        M83
+    {% endif %}
 
     # Material parameters
     {% if firmware_retraction_enabled %}

--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -94,13 +94,7 @@ gcode:
     M221 S100
     M220 S100
     G90
-    {% if extrusion_absolute_mode %}
-        RESPOND MSG="Setting Absolute Extrusion Mode"
-        M82
-    {% else %}
-        RESPOND MSG="Setting Relative Extrusion Mode"
-        M83
-    {% endif %}
+    M83
 
     # Material parameters
     {% if firmware_retraction_enabled %}
@@ -173,6 +167,13 @@ gcode:
         RESPOND MSG="Start printing !"
     {% endif %}
 
+    {% if extrusion_absolute_mode %}
+        RESPOND MSG="Setting Absolute Extrusion Mode"
+        M82
+    {% else %}
+        RESPOND MSG="Setting Relative Extrusion Mode"
+        M83
+    {% endif %}
     G92 E0.0
 
 

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -71,7 +71,8 @@ variable_disable_motors_in_end_print: False
 ## Automatically turn-off heaters in the END_PRINT macro
 variable_turn_off_heaters_in_end_print: True
 
-
+## Define the extrusion mode to be absolute/relative, default to Relative
+variable_extrusion_absolute_mode: False
 #########################################################
 # Dockable probe variables (if available in the machine)
 #########################################################

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -73,6 +73,7 @@ variable_turn_off_heaters_in_end_print: True
 
 ## Define the extrusion mode to be absolute/relative, default to Relative
 variable_extrusion_absolute_mode: False
+
 #########################################################
 # Dockable probe variables (if available in the machine)
 #########################################################


### PR DESCRIPTION
Added a variable defaulted to False, to allow selection between absolute and relative extrusion.

Default value: 
variable_extrusion_absolute_mode: False

To enable absolute extrusion mode set it to:
variable_extrusion_absolute_mode: True