### PR TITLE
Support Rainbow Barf style LEDs with the current LED macro implementation

### DIFF
--- a/config/hardware/lights/rainbow_barf_status_leds.cfg
+++ b/config/hardware/lights/rainbow_barf_status_leds.cfg
@@ -1,0 +1,30 @@
+# Neopixel leds used on the toolhead (rainvow barf style, 8 GRB leds on logo + 2 GRBW leds on the nozzle)
+[gcode_macro _USER_VARIABLES]
+variable_status_leds_enabled: True
+variable_status_leds_logo_led_name: "status_leds"
+variable_status_leds_logo_idx: '1,2,3,4,5,6,7,8'
+variable_status_leds_nozzle_led_name: "status_leds"
+variable_status_leds_nozzle_idx: '9,10'
+gcode:
+
+# Also include directly the leds control macros from here
+[include ../../../macros/hardware_functions/status_leds.cfg]
+
+
+[neopixel status_leds]
+pin: STATUS_NEOPIXEL
+#   The pin connected to the neopixel. This parameter must be provided.
+chain_count: 10
+#   The number of Neopixel chips that are "daisy chained" to the
+#   provided pin. The default is 1 (which indicates only a single
+#   Neopixel is connected to the pin).
+color_order: GRB,GRB,GRB,GRB,GRB,GRB,GRB,GRB,GRBW,GRBW
+#   Set the pixel order required by the LED hardware. Options are GRB,
+#   RGB, GRBW, or RGBW. The default is GRB.
+initial_RED: 0.0
+initial_GREEN: 0.0
+initial_BLUE: 0.0
+initial_WHITE: 0.0
+#   Sets the initial LED color of the Neopixel. Each value should be
+#   between 0.0 and 1.0. The WHITE option is only available on RGBW
+#   LEDs. The default for each color is 0.#

--- a/user_templates/printer.cfg
+++ b/user_templates/printer.cfg
@@ -156,6 +156,7 @@
 # [include config/hardware/lights/fcob_white.cfg]
 # [include config/hardware/lights/neopixel_caselight.cfg]
 # [include config/hardware/lights/status_leds.cfg]
+# [include config/hardware/lights/rainbow_barf_status_leds.cfg]
 # ----------------------------------------------------------------------------------------
 
 


### PR DESCRIPTION
I know Rainbow Barf toolhead support is scheduled for next version (#164) but I figured out a simple way to add support for it while keeping the current macro implementation. It has no support for animations but it works as expected (logo and nozzle leds changes color according to Status). All I did was change the chain count, add the correct RGB ordering and changed the index variables with the correct indexes for each led.
