### PR TITLE
added fix for rsense for TMC5160

### DIFF
--- a/config/hardware/axis/X/TMC/TMC5160.cfg
+++ b/config/hardware/axis/X/TMC/TMC5160.cfg
@@ -11,5 +11,5 @@ spi_software_mosi_pin: DRIVER_SPI_MOSI
 spi_software_miso_pin: DRIVER_SPI_MISO
 interpolate: True
 run_current: 0.8
-sense_resistor: 0.110
+sense_resistor: 0.075
 stealthchop_threshold: 0

--- a/config/hardware/axis/Y/TMC/TMC5160.cfg
+++ b/config/hardware/axis/Y/TMC/TMC5160.cfg
@@ -11,5 +11,5 @@ spi_software_mosi_pin: DRIVER_SPI_MOSI
 spi_software_miso_pin: DRIVER_SPI_MISO
 interpolate: True
 run_current: 0.8
-sense_resistor: 0.110
+sense_resistor: 0.075
 stealthchop_threshold: 0


### PR DESCRIPTION
resistor_sense was defaulted to a value that is not common for TMC5160.
This adds the documented value of 0.075 instead of 0.110