### PR TITLE
Update primeline so that it runs along the rectangle of the first layer

### DIFF
--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -29,7 +29,7 @@ gcode:
     {% set TOOLS_USED = params.TOOLS_USED|default("")|string %} # Check if MMU gates (used in gcode file) are availables
     {% set SYNC_MMU_EXTRUDER = params.SYNC_MMU_EXTRUDER|default(0)|int %} # set MMU gear motor and extruder synchronization during print TODO
     {% set BED_MESH_PROFILE = params.MESH|default("")|string %} # Bed mesh profile to load
-    {% set ADAPTIVE_PRIMELINE = params.ADAPTIVE_PRIMELINE|default(True) %} # Weither to do or not an adaptive prime line near the real print zone
+    {% set ADAPTIVE_PRIMELINE = params.ADAPTIVE_PRIMELINE|default(1)|int %} # Weither to do or not an adaptive prime line near the real print zone
 
     # Set the variables to be used in all the modules based on the slicer parameters
     SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=bed_temp VALUE={BED_TEMP}

--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -29,6 +29,7 @@ gcode:
     {% set TOOLS_USED = params.TOOLS_USED|default("")|string %} # Check if MMU gates (used in gcode file) are availables
     {% set SYNC_MMU_EXTRUDER = params.SYNC_MMU_EXTRUDER|default(0)|int %} # set MMU gear motor and extruder synchronization during print TODO
     {% set BED_MESH_PROFILE = params.MESH|default("")|string %} # Bed mesh profile to load
+    {% set ADAPTIVE_PRIMELINE = params.ADAPTIVE_PRIMELINE|default(True) %} # Weither to do or not an adaptive prime line near the real print zone
 
     # Set the variables to be used in all the modules based on the slicer parameters
     SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=bed_temp VALUE={BED_TEMP}
@@ -43,6 +44,7 @@ gcode:
     SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=material VALUE='"{MATERIAL}"'
     SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=fl_size VALUE='"{FL_SIZE}"'
     SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=bed_mesh_profile VALUE='"{BED_MESH_PROFILE}"'
+    SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=adaptive_primeline VALUE={ADAPTIVE_PRIMELINE}
     
     {% if params.TOTAL_LAYER %} # total layers count (if provided by the slicer)
         SET_PRINT_STATS_INFO TOTAL_LAYER={params.TOTAL_LAYER|int}
@@ -193,7 +195,15 @@ gcode:
 
 [gcode_macro _MODULE_PRIMELINE]
 gcode:
-    PRIMELINE
+    # ----- PRIME LINE -------------------------------------------
+    {% set FL_SIZE = printer["gcode_macro START_PRINT"].fl_size %}
+    {% set ADAPTIVE_PRIMELINE = printer["gcode_macro START_PRINT"].adaptive_primeline %}
+    {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
+
+    {% if verbose %}
+        RESPOND MSG="Executing a primeline..."
+    {% endif %}
+    PRIMELINE SIZE={FL_SIZE} ADAPTIVE_MODE={ADAPTIVE_PRIMELINE}
 
 
 [gcode_macro _MODULE_HEATSOAK_BED]
@@ -398,7 +408,6 @@ gcode:
             {% if verbose %}
                 RESPOND MSG="Bed mesh measurement..."
             {% endif %}
-
             ADAPTIVE_BED_MESH SIZE={FL_SIZE}
         {% else %}
             {% if verbose %}

--- a/macros/helpers/prime_line.cfg
+++ b/macros/helpers/prime_line.cfg
@@ -1,18 +1,46 @@
 [gcode_macro PRIMELINE]
 gcode:
-    # Macro parameters
+    # Base macro parameters
     {% set prime_line_length = params.LINE_LENGTH|default(printer["gcode_macro _USER_VARIABLES"].prime_line_length)|float %}
     {% set prime_line_purge_distance = params.PURGE_LENGTH|default(printer["gcode_macro _USER_VARIABLES"].prime_line_purge_distance)|float %}
     {% set prime_line_flowrate = params.FLOWRATE|default(printer["gcode_macro _USER_VARIABLES"].prime_line_flowrate)|float %}
-    {% if printer["gcode_macro _USER_VARIABLES"].prime_line_height %}
-      {% set prime_line_height = params.LINE_HEIGHT|default(printer["gcode_macro _USER_VARIABLES"].prime_line_height)|float %}
-    {% else %}
-      {% set prime_line_height = params.LINE_HEIGHT|default(0.6)|float %}
+    {% set prime_line_height = params.LINE_HEIGHT|default(printer["gcode_macro _USER_VARIABLES"].prime_line_height)|default(0.6)|float %}
+    {% set prime_line_adaptive = params.ADAPTIVE_MODE|default(True) %}
+    
+    # If the SIZE parameter is defined and not a dummy placeholder, we use it to do the adaptive bed mesh logic
+    {% set coordinatesFound = false %}
+    {% if params.SIZE is defined and params.SIZE != "0_0_0_0" %}
+        {% set xMinSpec, yMinSpec, xMaxSpec, yMaxSpec = params.SIZE.split('_')|map('trim')|map('int') %}
+        {% set coordinatesFound = true %}
+    {% elif printer.exclude_object is defined %}
+        {% if printer.exclude_object.objects %}
+            # Else if SIZE is not defined, we fallback to use the [exclude_object] tags
+            # This method is derived from Kyleisah KAMP repository: https://github.com/kyleisah/Klipper-Adaptive-Meshing-Purging)
+            {% set eo_points = printer.exclude_object.objects|map(attribute='polygon')|sum(start=[]) %}
+            {% set xMinSpec = eo_points|map(attribute=0)|min %}
+            {% set yMinSpec = eo_points|map(attribute=1)|min %}
+            {% set xMaxSpec = eo_points|map(attribute=0)|max %}
+            {% set yMaxSpec = eo_points|map(attribute=1)|max %}
+            {% set coordinatesFound = true %}
+        {% endif %}
     {% endif %}
 
-    # Set internal macro vars
+    # We get the default prime line position parameters
     {% set prime_line_x, prime_line_y = printer["gcode_macro _USER_VARIABLES"].prime_line_xy|map('float') %}
-    {% set prime_line_direction = printer["gcode_macro _USER_VARIABLES"].prime_line_direction|string|upper %}
+    {% set prime_line_x = params.START_X|default(prime_line_x)|float %}
+    {% set prime_line_y = params.START_Y|default(prime_line_y)|float %}
+    {% set prime_line_direction = params.LINE_DIRECTION|default(printer["gcode_macro _USER_VARIABLES"].prime_line_direction)|string|upper %}
+
+    # If first layer is retrieved and adaptive mode is enabled, then we replace the coordinates to do an adaptive purge
+    {% if coordinatesFound and prime_line_adaptive %}
+        {% set prime_line_margin = params.LINE_MARGIN|default(printer["gcode_macro _USER_VARIABLES"].prime_line_margin)|default(5.0)|float %}
+        {% set prime_line_x = [[prime_line_x, xMinSpec - prime_line_margin]|max, xMaxSpec + prime_line_margin]|min %}
+        {% set prime_line_y = [[prime_line_y, yMinSpec - prime_line_margin]|max, yMaxSpec + prime_line_margin]|min %}
+    {% endif %}
+
+    # Choose the way of printing the primeline (in + or -) alongside the direction to avoid going outside the bed boundaries
+    {% set axes_max = printer.toolhead.axis_maximum %}
+    {% set prime_line_way = -1 if (prime_line_direction == "X" and prime_line_x > axes_max.x/2) or (prime_line_direction == "Y" and prime_line_y > axes_max.y/2) else 1 %}
 
     {% set St = printer["gcode_macro _USER_VARIABLES"].travel_speed * 60 %}
     {% set Sz = printer["gcode_macro _USER_VARIABLES"].z_drop_speed * 60 %}
@@ -25,31 +53,6 @@ gcode:
     {% set max_extrude_cross_section = printer["configfile"].config["extruder"]["max_extrude_cross_section"]|float %}
     {% set filament_diameter = printer["configfile"].config["extruder"]["filament_diameter"]|float %}
     
-    # some more Macro parameters after retrieving defaults
-    {% set prime_line_x = params.START_X|default(prime_line_x)|float %}
-    {% set prime_line_y = params.START_Y|default(prime_line_y)|float %}
-    {% set prime_line_direction = params.LINE_DIRECTION|default(printer["gcode_macro _USER_VARIABLES"].prime_line_direction)|string|upper %}
-
-    # Redefine start position from fl_size 
-    {% set fl_size=printer['gcode_macro START_PRINT'].fl_size %}
-    {% if fl_size != "0_0_0_0" %}
-        {% set prime_line_margin = printer["gcode_macro _USER_VARIABLES"].prime_line_margin|default(5.0)|float %}
-        {% set prime_line_margin = params.LINE_MARGIN|default(prime_line_margin|float) %}
-        {% set min_x, min_y, max_x, max_y = fl_size.split("_")|map('float') %}
-        {% set prime_line_x = [[prime_line_x, min_x - prime_line_margin] | max, max_x + prime_line_margin] | min %}
-        {% set prime_line_y = [[prime_line_y, min_y - prime_line_margin] | max, max_y + prime_line_margin] | min %}
-    {% endif %}
-
-    {% set axes_max = printer.toolhead.axis_maximum %}
-    {% set prime_line_way = -1 if (prime_line_direction == "X" and prime_line_x > axes_max.x/2) or (prime_line_direction == "Y" and prime_line_y > axes_max.y/2) else 1 %}
-
-
-    {% if verbose %}
-        {action_respond_info("Prime line length: %.4f" % prime_line_length)}
-        {action_respond_info("Prime line eight: %.4f" % prime_line_height)}
-        {action_respond_info("prime line extrusion length: %4.f" % prime_line_purge_distance)}
-    {% endif %} 
-
     # We first compute the width of the prime line
     {% set purge_volume = prime_line_purge_distance * 3.14159 * (filament_diameter / 2)**2 %}
     {% set line_width = purge_volume / (prime_line_height * prime_line_length) %}
@@ -71,7 +74,7 @@ gcode:
     # We then compute the height to width ratio and validate that the prime line will not be too thin
     {% if (prime_line_height / line_width) >= 0.5 %} # TODO: validate this 1/2 ratio is good for all
         {% if verbose %}
-            {action_raise_error("The prime line will be too thin and will probably not stick properly to the bed. Increase its purge distance or decrease its length! Aborting...")}
+            {action_raise_error("The prime line will be too thin and will probably not stick properly to the bed. Increase its purge distance or decrease its length!")}
         {% endif %}
     {% endif %}
 
@@ -106,12 +109,10 @@ gcode:
 
     # Prime line
     G92 E0
-
     {% if prime_line_direction == "X" %}
         G1 X{prime_line_x + prime_line_way*prime_line_length} E{prime_line_purge_distance} F{speed}
     {% elif prime_line_direction == "Y" %}
         G1 Y{prime_line_y + prime_line_way*prime_line_length} E{prime_line_purge_distance} F{speed}
-
     {% else %}
         { action_respond_error("Prime line direction is not valid. Choose either X or Y in the variables.cfg file!") }
     {% endif %}
@@ -121,6 +122,12 @@ gcode:
     G1 E-0.2 F2100
     G92 E0
     G1 Z3 F{Sz}
+
+    # Additional small movement to get out of the line as some slicers directly emmit
+    # a Z- move as a first step that make the toolhead crash back in the line and get dirty
+    G91
+    G1 X2 Y2 F{St}
+    G90
     
     # Flushing Klipper's buffer to ensure the primeline sequence is done before continuing
     M400
@@ -132,4 +139,3 @@ gcode:
     {% if filament_sensor_enabled and re_enable_filament_sensor %}
         SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=1
     {% endif %}
-    

--- a/macros/helpers/prime_line.cfg
+++ b/macros/helpers/prime_line.cfg
@@ -30,6 +30,19 @@ gcode:
     {% set prime_line_y = params.START_Y|default(prime_line_y)|float %}
     {% set prime_line_direction = params.LINE_DIRECTION|default(printer["gcode_macro _USER_VARIABLES"].prime_line_direction)|string|upper %}
 
+    # Redefine start position from fl_size 
+    {% set fl_size=printer['gcode_macro START_PRINT'].fl_size %}
+    {% if fl_size != "0_0_0_0" %}
+        {% set prime_line_margin = params.LINE_MARGIN|default(printer["gcode_macro _USER_VARIABLES"].prime_line_margin|float) %}
+        {% set min_x, min_y, max_x, max_y = fl_size.split("_")|map('float') %}
+        {% set prime_line_x = [[prime_line_x, min_x - prime_line_margin] | max, max_x + prime_line_margin] | min %}
+        {% set prime_line_y = [[prime_line_y, min_y - prime_line_margin] | max, max_y + prime_line_margin] | min %}
+    {% endif %}
+
+    {% set axes_max = printer.toolhead.axis_maximum %}
+    {% set prime_line_way = -1 if (prime_line_direction == "X" and prime_line_x > axes_max.x/2) or (prime_line_direction == "Y" and prime_line_y > axes_max.y/2) else 1 %}
+
+
     {% if verbose %}
         {action_respond_info("Prime line length: %.4f" % prime_line_length)}
         {action_respond_info("Prime line eight: %.4f" % prime_line_height)}
@@ -92,10 +105,12 @@ gcode:
 
     # Prime line
     G92 E0
+
     {% if prime_line_direction == "X" %}
-        G1 X{prime_line_x + prime_line_length} E{prime_line_purge_distance} F{speed}
+        G1 X{prime_line_x + prime_line_way*prime_line_length} E{prime_line_purge_distance} F{speed}
     {% elif prime_line_direction == "Y" %}
-        G1 Y{prime_line_y + prime_line_length} E{prime_line_purge_distance} F{speed}
+        G1 Y{prime_line_y + prime_line_way*prime_line_length} E{prime_line_purge_distance} F{speed}
+
     {% else %}
         { action_respond_error("Prime line direction is not valid. Choose either X or Y in the variables.cfg file!") }
     {% endif %}
@@ -116,3 +131,4 @@ gcode:
     {% if filament_sensor_enabled and re_enable_filament_sensor %}
         SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=1
     {% endif %}
+    

--- a/macros/helpers/prime_line.cfg
+++ b/macros/helpers/prime_line.cfg
@@ -33,7 +33,7 @@ gcode:
     # Redefine start position from fl_size 
     {% set fl_size=printer['gcode_macro START_PRINT'].fl_size %}
     {% if fl_size != "0_0_0_0" %}
-        {% set prime_line_margin = printer["gcode_macro _USER_VARIABLES"].prime_line_margin|default(5.0|float) %}
+        {% set prime_line_margin = printer["gcode_macro _USER_VARIABLES"].prime_line_margin|default(5.0)|float %}
         {% set prime_line_margin = params.LINE_MARGIN|default(prime_line_margin|float) %}
         {% set min_x, min_y, max_x, max_y = fl_size.split("_")|map('float') %}
         {% set prime_line_x = [[prime_line_x, min_x - prime_line_margin] | max, max_x + prime_line_margin] | min %}

--- a/macros/helpers/prime_line.cfg
+++ b/macros/helpers/prime_line.cfg
@@ -5,7 +5,8 @@ gcode:
     {% set prime_line_purge_distance = params.PURGE_LENGTH|default(printer["gcode_macro _USER_VARIABLES"].prime_line_purge_distance)|float %}
     {% set prime_line_flowrate = params.FLOWRATE|default(printer["gcode_macro _USER_VARIABLES"].prime_line_flowrate)|float %}
     {% set prime_line_height = params.LINE_HEIGHT|default(printer["gcode_macro _USER_VARIABLES"].prime_line_height)|default(0.6)|float %}
-    {% set prime_line_adaptive = params.ADAPTIVE_MODE|default(True) %}
+    {% set prime_line_adaptive = params.ADAPTIVE_MODE|default(1)|int %}
+    {% set prime_line_margin = params.LINE_MARGIN|default(printer["gcode_macro _USER_VARIABLES"].prime_line_margin)|default(5.0)|float %} # Used only in adaptive mode
     
     # If the SIZE parameter is defined and not a dummy placeholder, we use it to do the adaptive bed mesh logic
     {% set coordinatesFound = false %}
@@ -31,16 +32,22 @@ gcode:
     {% set prime_line_y = params.START_Y|default(prime_line_y)|float %}
     {% set prime_line_direction = params.LINE_DIRECTION|default(printer["gcode_macro _USER_VARIABLES"].prime_line_direction)|string|upper %}
 
-    # If first layer is retrieved and adaptive mode is enabled, then we replace the coordinates to do an adaptive purge
-    {% if coordinatesFound and prime_line_adaptive %}
-        {% set prime_line_margin = params.LINE_MARGIN|default(printer["gcode_macro _USER_VARIABLES"].prime_line_margin)|default(5.0)|float %}
+    {% set center_x, center_y = [printer.toolhead.axis_maximum.x / 2, printer.toolhead.axis_maximum.y / 2]|map("float") %}
+    
+    # If first layer coordinates are retrieved and adaptive mode is enabled, then we replace the coordinates to
+    # do an adaptive purge while being careful to have the line stay on the bed when the first layer
+    # is in an opposite bed quadrant than the prime line initial coordinates (due to mirrored coordinates from center axes)...
+    {% if coordinatesFound and prime_line_adaptive == 1 %}
+        {% set prime_line_x = 2*center_x - prime_line_x if (prime_line_x > center_x and xMaxSpec < center_x) or (prime_line_x < center_x and xMinSpec > center_x) 
+                               else prime_line_x %}
+        {% set prime_line_y = 2*center_y - prime_line_y if (prime_line_y > center_y and yMaxSpec < center_y) or (prime_line_y < center_y and yMinSpec > center_y) 
+                               else prime_line_y %}
         {% set prime_line_x = [[prime_line_x, xMinSpec - prime_line_margin]|max, xMaxSpec + prime_line_margin]|min %}
         {% set prime_line_y = [[prime_line_y, yMinSpec - prime_line_margin]|max, yMaxSpec + prime_line_margin]|min %}
     {% endif %}
 
     # Choose the way of printing the primeline (in + or -) alongside the direction to avoid going outside the bed boundaries
-    {% set axes_max = printer.toolhead.axis_maximum %}
-    {% set prime_line_way = -1 if (prime_line_direction == "X" and prime_line_x > axes_max.x/2) or (prime_line_direction == "Y" and prime_line_y > axes_max.y/2) else 1 %}
+    {% set prime_line_way = -1 if (prime_line_direction == "X" and prime_line_x > center_x) or (prime_line_direction == "Y" and prime_line_y > center_y) else 1 %}
 
     {% set St = printer["gcode_macro _USER_VARIABLES"].travel_speed * 60 %}
     {% set Sz = printer["gcode_macro _USER_VARIABLES"].z_drop_speed * 60 %}
@@ -73,9 +80,7 @@ gcode:
 
     # We then compute the height to width ratio and validate that the prime line will not be too thin
     {% if (prime_line_height / line_width) >= 0.5 %} # TODO: validate this 1/2 ratio is good for all
-        {% if verbose %}
-            {action_raise_error("The prime line will be too thin and will probably not stick properly to the bed. Increase its purge distance or decrease its length!")}
-        {% endif %}
+        {action_raise_error("The prime line will be too thin and will probably not stick properly to the bed. Increase its purge distance or decrease its length!")}
     {% endif %}
 
     # Finally we compute the speed to get the correct flowrate for the prime line

--- a/macros/helpers/prime_line.cfg
+++ b/macros/helpers/prime_line.cfg
@@ -33,7 +33,8 @@ gcode:
     # Redefine start position from fl_size 
     {% set fl_size=printer['gcode_macro START_PRINT'].fl_size %}
     {% if fl_size != "0_0_0_0" %}
-        {% set prime_line_margin = params.LINE_MARGIN|default(printer["gcode_macro _USER_VARIABLES"].prime_line_margin|float) %}
+        {% set prime_line_margin = printer["gcode_macro _USER_VARIABLES"].prime_line_margin|default(5.0|float) %}
+        {% set prime_line_margin = params.LINE_MARGIN|default(prime_line_margin|float) %}
         {% set min_x, min_y, max_x, max_y = fl_size.split("_")|map('float') %}
         {% set prime_line_x = [[prime_line_x, min_x - prime_line_margin] | max, max_x + prime_line_margin] | min %}
         {% set prime_line_y = [[prime_line_y, min_y - prime_line_margin] | max, max_y + prime_line_margin] | min %}

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -61,6 +61,7 @@ variable_prime_line_length: 40 # length of the prime line on the bed (in mm)
 variable_prime_line_purge_distance: 30 # length of filament to purge (in mm)
 variable_prime_line_flowrate: 10 # mm3/s used for the prime line
 variable_prime_line_height: 0.6 # mm, used for actual cross section computation
+variable_prime_line_margin: 5  # distance of purge line from fl_size rectangle
 
 ## Park position used when pause, end_print, etc...
 variable_park_position_xy: -1, -1


### PR DESCRIPTION
Thanks to @fbeauKmi 

Now `prime_line_xy` defines the origin of the baseline
The primeline is made on the corner of the `FL_SIZE` rectangle closest to the origin.

Add Variable `prime_line_margin` wich define distance of purge line from fl_size rectangle

If `FL_SIZE` is not defined, old primeline is used