### PR TITLE
avoid led effect flashing on startup if leds desabled on startup

### DIFF
--- a/config/hardware/lights/neopixel_caselight_effects.cfg
+++ b/config/hardware/lights/neopixel_caselight_effects.cfg
@@ -168,7 +168,7 @@ layers:
 [led_effect cl_startup]
 leds:
     neopixel:caselight
-autostart:                          true
+autostart:                          false
 frame_rate:                         24
 layers:
     gradient  0.3  1 add (1.0, 0.0, 0.0),(0.0, 1.0, 0.0),(0.0, 0.0, 1.0)

--- a/config/hardware/lights/status_leds_effects.cfg
+++ b/config/hardware/lights/status_leds_effects.cfg
@@ -213,7 +213,7 @@ layers:
 [led_effect startup]
 leds:
     neopixel:status_leds
-autostart:                          true
+autostart:                          false
 frame_rate:                         24
 layers:
     gradient  0.3  1 add (1.0, 0.0, 0.0),(0.0, 1.0, 0.0),(0.0, 0.0, 1.0)

--- a/config/hardware/lights/status_leds_rainbow_barf_effects.cfg
+++ b/config/hardware/lights/status_leds_rainbow_barf_effects.cfg
@@ -213,7 +213,7 @@ layers:
 [led_effect startup]
 leds:
     neopixel:status_leds
-autostart:                          true
+autostart:                          false
 frame_rate:                         24
 layers:
     gradient  0.3  1 add (1.0, 0.0, 0.0),(0.0, 1.0, 0.0),(0.0, 0.0, 1.0)


### PR DESCRIPTION
the autostart function for led_effect must be desabled to avoid led flashing on startup