### PR TITLE
add a variable to be able to override some future mmu variables

### DIFF
--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -197,11 +197,12 @@ variable_material_parameters: {
 ################################################
 ## This section is only considered if an MMU/ERCF is installed and configured
 
+variable_mmu_use_klippain_variables: True           # True to be able to overrides some _MMU_SEQUENCE_VARS variables
 variable_mmu_force_homing_in_start_print: False
 variable_mmu_unload_on_cancel_print: False
 variable_mmu_unload_on_end_print: True
-variable_mmu_check_gates_on_start_print: False   # True is recommended but you must have TOOLS_USED=!referenced_tools! in your slicer START_PRINT parameters. Otherwise it will only check the INITIAL TOOL...
-variable_mmu_check_errors_on_start_print: False  # Set to True if you want an early check of MMU errors during the START_PRINT sequence.
+variable_mmu_check_gates_on_start_print: False      # True is recommended but you must have TOOLS_USED=!referenced_tools! in your slicer START_PRINT parameters. Otherwise it will only check the INITIAL TOOL...
+variable_mmu_check_errors_on_start_print: False     # Set to True if you want an early check of MMU errors during the START_PRINT sequence.
 
 ################################################
 ## Filter specific variables

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -195,9 +195,9 @@ variable_material_parameters: {
 ################################################
 ## MMU/ERCF specific variables
 ################################################
-## This section is only considered if an MMU/ERCF is installed and configured
+## This section is only considered if an MMU/ERCF is installed and configured by using Happy_Hare
 
-variable_mmu_use_klippain_variables: True           # True to be able to overrides some _MMU_SEQUENCE_VARS variables
+variable_mmu_use_klippain_variables: True           # True to let Klippain overrides some Happy_Hare variables (in _MMU_SEQUENCE_VARS and _MMU_SOFTWARE_VARS)
 variable_mmu_force_homing_in_start_print: False
 variable_mmu_unload_on_cancel_print: False
 variable_mmu_unload_on_end_print: True


### PR DESCRIPTION
in the future HH some variables are already define in HH. This variable can be use to choose between klippain default variables (for exemple for park position....) or the one define in the future upgrade of HH