### PR TITLE
Fix homing in error gcode

### DIFF
--- a/config/machine.cfg
+++ b/config/machine.cfg
@@ -4,7 +4,7 @@ on_error_gcode:
     {% if printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
         STATUS_LEDS COLOR="ERROR"
     {% endif %}
-    {% if printer["gcode_macro _USER_VARIABLES"].probe_type_enabled == "dockable" %}
+    {% if printer["gcode_macro _USER_VARIABLES"].probe_type_enabled == "dockable" or printer["gcode_macro _USER_VARIABLES"].probe_type_enabled == "dockable_virtual" %}
         _PROBE_ON_ERROR_ACTION
     {% endif %}
 

--- a/config/machine.cfg
+++ b/config/machine.cfg
@@ -1,13 +1,18 @@
 [virtual_sdcard]
 path: ~/printer_data/gcodes
 on_error_gcode:
-   {% if printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
-      STATUS_LEDS COLOR="ERROR"
-   {% endif %}
-   {% if printer["gcode_macro _USER_VARIABLES"].probe_type_enabled == "dockable" %}
-       _PROBE_ON_ERROR_ACTION
-   {% endif %}
-   PARK
+    {% if printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+        STATUS_LEDS COLOR="ERROR"
+    {% endif %}
+    {% if printer["gcode_macro _USER_VARIABLES"].probe_type_enabled == "dockable" %}
+        _PROBE_ON_ERROR_ACTION
+    {% endif %}
+
+    # Park only if printer is homed
+    {% if "xyz" in printer.toolhead.homed_axes %}
+        PARK
+    {% endif %}
+   
 
 [idle_timeout]
 timeout: 1800


### PR DESCRIPTION
When an error occurs in the gcode, we call `PARK`, but following PR #494  we force a home in the `PARK` macro.
I find it strange to do home when the job has an error.
I therefore propose to do `PARK` only when the machine is already homed.