### PR TITLE
Fix park with overrided param E

### DIFF
--- a/macros/base/park.cfg
+++ b/macros/base/park.cfg
@@ -23,6 +23,8 @@ gcode:
         {% set z_safe = max_z %}
     {% endif %}
 
+    SAVE_GCODE_STATE NAME=PARK
+
     _CG28 ; home if not already homed
 
     {% if printer.extruder.can_extrude %}
@@ -61,7 +63,8 @@ gcode:
     G90
     G1 Z{z_safe} F{Sz}
     G0 X{Px} Y{Py} F{St}
-
+    
+    RESTORE_GCODE_STATE NAME=PARK
 
 [gcode_macro PARK_FRONT]
 description: Park the toolhead on the front of the printer for maintenance

--- a/macros/base/park.cfg
+++ b/macros/base/park.cfg
@@ -56,7 +56,6 @@ gcode:
         {% if E is defined and E > 0 %}
             G92 E0
             G1 E-{E} F2100
-            RESPOND MSG="Extruder retraction = {E}"
         {% endif %}
     {% endif %}
 

--- a/macros/base/park.cfg
+++ b/macros/base/park.cfg
@@ -2,8 +2,7 @@
 description: Park the toolhead at the back and retract some filament if the nozzle is hot
 gcode:
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
-    {% set E = params.E|default(1.7)|float|abs %}
-    {% set MATERIAL = printer['gcode_macro START_PRINT'].material %}
+    {% set material = printer['gcode_macro START_PRINT'].material %}
 
     {% set Px, Py = printer["gcode_macro _USER_VARIABLES"].park_position_xy|map('float') %}
     {% set Px = params.X|default(Px)|float %}
@@ -27,21 +26,35 @@ gcode:
     _CG28 ; home if not already homed
 
     {% if printer.extruder.can_extrude %}
-        {% if firmware_retraction_enabled %}    # use firmware_retraction parameter for retract (in case firmware retraction is selected in printer.cfg)
+        {% if params.E is defined %}
+            {% set E = params.E|float|abs %}
+
             {% if verbose %}
-                RESPOND MSG="Firmware retraction enabled, Extruder retraction = {printer.firmware_retraction.retract_length}"
+                RESPOND MSG="Retraction overrided with parameter, Extruder retraction = {E}"
+            {% endif %}            
+        {% else %}
+            {% if firmware_retraction_enabled %}    # use firmware_retraction parameter for retract (in case firmware retraction is selected in printer.cfg)
+                {% if verbose %}
+                    RESPOND MSG="Firmware retraction enabled, Extruder retraction = {printer.firmware_retraction.retract_length}"
+                {% endif %}
+                G10
+            {% else %}                              # otherwise:
+                {% if printer["gcode_macro _USER_VARIABLES"].material_parameters[material] is defined %}          # use material parameter if available for retract, otherwise use default value
+                    {% set E = printer["gcode_macro _USER_VARIABLES"].material_parameters[material].retract_length|default(1.7) %}
+                {% else %}
+                    {% set E = 1.7 %}
+                {% endif %}
+
+                {% if verbose %}
+                    RESPOND MSG="Firmware retraction disabled, Extruder retraction = {E}"
+                {% endif %}
             {% endif %}
-            G10
-        {% else %}                              # otherwise:
-            {% if MATERIAL != "XXX" %}          # use material parameter if available for retract, otherwise use default value
-                {% set material = printer["gcode_macro _USER_VARIABLES"].material_parameters[MATERIAL] %}
-                {% set E = material.retract_length %}
-            {% endif %}
-            {% if verbose %}
-                RESPOND MSG="Firmware retraction disabled, Extruder retraction = {E}"
-            {% endif %}
+        {% endif %}
+
+        {% if E is defined and E > 0 %}
             G92 E0
             G1 E-{E} F2100
+            RESPOND MSG="Extruder retraction = {E}"
         {% endif %}
     {% endif %}
 


### PR DESCRIPTION
The `PARK` macro did not always take into account the overloading of the macro's E parameter.