### PR TITLE
Optimise start print homing

### DIFF
--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -313,6 +313,9 @@ gcode:
     # The correct operation is automatically selected in the _TILT_CALIBRATE macro
     {% set force_homing_in_start_print = printer["gcode_macro _USER_VARIABLES"].force_homing_in_start_print %}
     _TILT_CALIBRATE FORCE={force_homing_in_start_print}
+    {% if force_homing_in_start_print %}
+        G28 Z
+    {% endif %}
 
 
 [gcode_macro _MODULE_EXTRUDER_HEATING]


### PR DESCRIPTION
Add a Z homing in the _MODULE_TILTING module if force_homing_in_start_print is true, as it makes more sense to do a G28 Z just after tilting for the rest of the start print sequence.