### PR TITLE
adding option to enable/disable homing in park

### DIFF
--- a/macros/base/park.cfg
+++ b/macros/base/park.cfg
@@ -4,7 +4,7 @@ gcode:
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
     {% set E = params.E|default(1.7)|float|abs %}
     {% set MATERIAL = printer['gcode_macro START_PRINT'].material %}
-    {% set use_homing = printer["gcode_macro _USER_VARIABLES"].use_conditional_homing_in_park|int %}
+    {% set use_homing = printer["gcode_macro _USER_VARIABLES"].use_conditional_homing_in_park|default(1)|int %}
 
     {% set Px, Py = printer["gcode_macro _USER_VARIABLES"].park_position_xy|map('float') %}
     {% set Px = params.X|default(Px)|float %}

--- a/macros/base/park.cfg
+++ b/macros/base/park.cfg
@@ -4,6 +4,7 @@ gcode:
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
     {% set E = params.E|default(1.7)|float|abs %}
     {% set MATERIAL = printer['gcode_macro START_PRINT'].material %}
+    {% set use_homing = printer["gcode_macro _USER_VARIABLES"].use_conditional_homing_in_park|int %}
 
     {% set Px, Py = printer["gcode_macro _USER_VARIABLES"].park_position_xy|map('float') %}
     {% set Px = params.X|default(Px)|float %}
@@ -24,7 +25,9 @@ gcode:
         {% set z_safe = max_z %}
     {% endif %}
 
-    _CG28 ; home if not already homed
+    {% if use_homing %}
+        _CG28 ; home if not already homed
+    {% endif %}
 
     {% if printer.extruder.can_extrude %}
         {% if firmware_retraction_enabled %}    # use firmware_retraction parameter for retract (in case firmware retraction is selected in printer.cfg)
@@ -55,8 +58,11 @@ description: Park the toolhead on the front of the printer for maintenance
 gcode:
     {% set St = printer["gcode_macro _USER_VARIABLES"].travel_speed * 60 %}
     {% set Sz = printer["gcode_macro _USER_VARIABLES"].z_drop_speed * 60 %}
+    {% set use_homing = printer["gcode_macro _USER_VARIABLES"].use_conditional_homing_in_park|int %}
 
-    _CG28 ; home if not already homed
+    {% if use_homing %}
+        _CG28 ; home if not already homed
+    {% endif %}
 
     SAVE_GCODE_STATE NAME=PARK_FRONT
     G90      ; absolute positioning

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -67,6 +67,9 @@ variable_prime_line_margin: 5  # distance of purge line from fl_size rectangle
 variable_park_position_xy: -1, -1
 variable_park_lift_z: 50
 
+## Use Homing in PARK / PARK_FRONT if not homed
+variable_use_conditional_homing_in_park: False
+
 ## Automatically disable motors in the END_PRINT macro
 variable_disable_motors_in_end_print: False
 


### PR DESCRIPTION
added an alternative to prevent homing in park if required.

if m84 is called anywhere and the user forgets it and press park while the bed is full of prints, it does a G28 on the parts.

instead of reverting to the old system with an error, this can be configured via variable with this PR.
default is the "new behaviour" since it is already released