### PR TITLE
added variable for timeout handling

### DIFF
--- a/config/machine.cfg
+++ b/config/machine.cfg
@@ -12,17 +12,23 @@ on_error_gcode:
     {% if "xyz" in printer.toolhead.homed_axes %}
         PARK
     {% endif %}
-   
+
 
 [idle_timeout]
 timeout: 1800
 gcode:
+    {% set disable_motors = printer["gcode_macro _USER_VARIABLES"].disable_motors_on_timeout|default(1)|int %}
     RESPOND MSG="Idle timeout reached"
     TURN_OFF_HEATERS
-    M84
+
+    {% if disable_motors %}
+        M84
+    {% endif %}
+
     {% if printer["gcode_macro _USER_VARIABLES"].light_enabled %}
         LIGHT_OFF
     {% endif %}
+
     {% if printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
         STATUS_LEDS COLOR="OFF"
     {% endif %}

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -73,6 +73,8 @@ variable_disable_motors_in_end_print: False
 ## Automatically turn-off heaters in the END_PRINT macro
 variable_turn_off_heaters_in_end_print: True
 
+## Automatically disable motors on timeout
+variable_disable_motors_on_timeout: False
 
 #########################################################
 # Dockable probe variables (if available in the machine)


### PR DESCRIPTION
added variable to prevent calling M84 on timeout.
With the G2Z beta, gantry sag is a potenial issue, especially if toolhead is located near the edges.
with the introduced variable, it is now possible to prevent M84 on timeout.

it was copied based on the already existing end print variables, except that i did not added the heater off due to functional safety concerns.