### PR TITLE
Neopixel_caselight_enable

### DIFF
--- a/config/hardware/lights/neopixel_caselight.cfg
+++ b/config/hardware/lights/neopixel_caselight.cfg
@@ -1,6 +1,7 @@
 # Neopixel leds used as general printer lights
 
 [gcode_macro _USER_VARIABLES]
+variable_neopixel_leds_enabled = True
 variable_status_leds_caselight_enabled = True
 variable_status_leds_effects_enabled = False
 variable_status_leds_caselight_led_name: "caselight"

--- a/config/hardware/lights/neopixel_caselight_effects.cfg
+++ b/config/hardware/lights/neopixel_caselight_effects.cfg
@@ -2,6 +2,7 @@
 # using LED_effects
 
 [gcode_macro _USER_VARIABLES]
+variable_neopixel_leds_enabled = True
 variable_status_leds_caselight_enabled = True
 variable_status_leds_effects_enabled = True
 variable_status_leds_caselight_led_name: "caselight"

--- a/config/hardware/lights/status_leds.cfg
+++ b/config/hardware/lights/status_leds.cfg
@@ -1,6 +1,7 @@
 # Neopixel leds used on the toolhead (stealthburner style)
 
 [gcode_macro _USER_VARIABLES]
+variable_neopixel_leds_enabled = True
 variable_status_leds_enabled: True
 variable_status_leds_effects_enabled: False
 variable_status_leds_logo_led_name: "status_leds"

--- a/config/hardware/lights/status_leds_effects.cfg
+++ b/config/hardware/lights/status_leds_effects.cfg
@@ -2,6 +2,7 @@
 # using LED_effects
 
 [gcode_macro _USER_VARIABLES]
+variable_neopixel_leds_enabled = True
 variable_status_leds_enabled: True
 variable_status_leds_effects_enabled: True
 variable_status_leds_logo_led_name: "status_leds"

--- a/config/hardware/lights/status_leds_rainbow_barf.cfg
+++ b/config/hardware/lights/status_leds_rainbow_barf.cfg
@@ -2,6 +2,7 @@
 # in a rainbow barf pattern PCB
 
 [gcode_macro _USER_VARIABLES]
+variable_neopixel_leds_enabled = True
 variable_status_leds_enabled: True
 variable_status_leds_effects_enabled: False
 variable_status_leds_logo_led_name: "status_leds"

--- a/config/hardware/lights/status_leds_rainbow_barf_effects.cfg
+++ b/config/hardware/lights/status_leds_rainbow_barf_effects.cfg
@@ -2,6 +2,7 @@
 # in a rainbow barf pattern PCB using LED_effects
 
 [gcode_macro _USER_VARIABLES]
+variable_neopixel_leds_enabled = True
 variable_status_leds_enabled: True
 variable_status_leds_effects_enabled: True
 variable_status_leds_logo_led_name: "status_leds"

--- a/config/machine.cfg
+++ b/config/machine.cfg
@@ -1,7 +1,7 @@
 [virtual_sdcard]
 path: ~/printer_data/gcodes
 on_error_gcode:
-    {% if printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% if printer["gcode_macro _USER_VARIABLES"].neopixel_leds_enabled %}
         STATUS_LEDS COLOR="ERROR"
     {% endif %}
     {% if printer["gcode_macro _USER_VARIABLES"].probe_type_enabled == "dockable" or printer["gcode_macro _USER_VARIABLES"].probe_type_enabled == "dockable_virtual" %}
@@ -23,7 +23,7 @@ gcode:
     {% if printer["gcode_macro _USER_VARIABLES"].light_enabled %}
         LIGHT_OFF
     {% endif %}
-    {% if printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% if printer["gcode_macro _USER_VARIABLES"].neopixel_leds_enabled %}
         STATUS_LEDS COLOR="OFF"
     {% endif %}
 

--- a/macros/base/cancel_print.cfg
+++ b/macros/base/cancel_print.cfg
@@ -9,7 +9,7 @@ gcode:
     {% set mmu_unload_on_cancel_print = printer["gcode_macro _USER_VARIABLES"].mmu_unload_on_cancel_print %}
     {% set filter_enabled = printer["gcode_macro _USER_VARIABLES"].filter_enabled %}
     {% set light_enabled = printer["gcode_macro _USER_VARIABLES"].light_enabled %}
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set neopixel_leds_enabled = printer["gcode_macro _USER_VARIABLES"].neopixel_leds_enabled %}
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
     {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
     {% set filter_default_time = printer["gcode_macro _USER_VARIABLES"].filter_default_time_on_end_print|default(600)|int %}
@@ -62,7 +62,7 @@ gcode:
     {% if light_enabled %}
         LIGHT_ON S={light_intensity_end_print}
     {% endif %}
-    {% if status_leds_enabled %}
+    {% if neopixel_leds_enabled %}
         STATUS_LEDS COLOR="OFF"
     {% endif %}
 

--- a/macros/base/control.cfg
+++ b/macros/base/control.cfg
@@ -2,7 +2,7 @@
 description: Turn off the printer
 gcode:
     {% set light_enabled = printer["gcode_macro _USER_VARIABLES"].light_enabled %}
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %} 
+    {% set neopixel_leds_enabled = printer["gcode_macro _USER_VARIABLES"].neopixel_leds_enabled %} 
     {% set display_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_minidisplay_enabled %}
     M84                                                             ; turn steppers off
     TURN_OFF_HEATERS                                                ; turn bed / hotend off
@@ -10,7 +10,7 @@ gcode:
     {% if light_enabled %}
         LIGHT_OFF                                                   ; turn off light
     {% endif %}
-    {% if status_leds_enabled %}
+    {% if neopixel_leds_enabled %}
         STATUS_LEDS COLOR="SHUTDOWN"                                     ; turn off status LEDs
     {% endif %}
     {% if display_leds_enabled %}

--- a/macros/base/end_print.cfg
+++ b/macros/base/end_print.cfg
@@ -9,7 +9,7 @@ gcode:
     {% set mmu_unload = params.MMU_UNLOAD_AT_END|default(printer["gcode_macro _USER_VARIABLES"].mmu_unload_on_end_print)|default(0)|int %}
     {% set filter_enabled = printer["gcode_macro _USER_VARIABLES"].filter_enabled %}
     {% set light_enabled = printer["gcode_macro _USER_VARIABLES"].light_enabled %}
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set neopixel_leds_enabled = printer["gcode_macro _USER_VARIABLES"].neopixel_leds_enabled %}
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
     {% set filter_default_time = printer["gcode_macro _USER_VARIABLES"].filter_default_time_on_end_print|default(600)|int %}
     {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
@@ -63,7 +63,7 @@ gcode:
     {% if light_enabled %}
         LIGHT_ON S={light_intensity_end_print}
     {% endif %}
-    {% if status_leds_enabled %}
+    {% if neopixel_leds_enabled %}
         STATUS_LEDS COLOR="DONE_PRINTING"
     {% endif %}
 

--- a/macros/base/homing/homing_conditional.cfg
+++ b/macros/base/homing/homing_conditional.cfg
@@ -1,14 +1,14 @@
 [gcode_macro _CG28]
 description: Homing only if necessary
 gcode:
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set neopixel_leds_enabled = printer["gcode_macro _USER_VARIABLES"].neopixel_leds_enabled %}
 
     {% if "xyz" not in printer.toolhead.homed_axes %}
-        {% if status_leds_enabled %}
+        {% if neopixel_leds_enabled %}
             STATUS_LEDS COLOR="HOMING"
         {% endif %}
         G28
-        {% if status_leds_enabled %}
+        {% if neopixel_leds_enabled %}
             STATUS_LEDS COLOR="READY"
         {% endif %}  
     {% endif %}

--- a/macros/base/homing/homing_override.cfg
+++ b/macros/base/homing/homing_override.cfg
@@ -14,7 +14,7 @@ gcode:
     {% set y_driver = printer["gcode_macro _USER_VARIABLES"].y_driver %}
     {% set z_driver = printer["gcode_macro _USER_VARIABLES"].z_driver %}
     {% set z_drop_speed = printer["gcode_macro _USER_VARIABLES"].z_drop_speed * 60 %}
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set neopixel_leds_enabled = printer["gcode_macro _USER_VARIABLES"].neopixel_leds_enabled %}
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
 
     {% set homing_first = printer["gcode_macro _USER_VARIABLES"].homing_first|string|upper %}
@@ -33,7 +33,7 @@ gcode:
     # reset parameters
     {% set X, Y, Z = False, False, False %}
 
-    {% if status_leds_enabled %}
+    {% if neopixel_leds_enabled %}
         STATUS_LEDS COLOR="HOMING"
     {% endif %}
 
@@ -346,7 +346,7 @@ gcode:
         _EXIT_POINT FUNCTION=homing_override
     {% endif %}
 
-    {% if status_leds_enabled %}
+    {% if neopixel_leds_enabled %}
         STATUS_LEDS COLOR="READY"
     {% endif %}
 

--- a/macros/base/homing/z_calibration.cfg
+++ b/macros/base/homing/z_calibration.cfg
@@ -4,9 +4,9 @@ description: Perform the Z calibration using the physical Z endstop and the dock
 gcode:
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set neopixel_leds_enabled = printer["gcode_macro _USER_VARIABLES"].neopixel_leds_enabled %}
 
-    {% if status_leds_enabled %}
+    {% if neopixel_leds_enabled %}
         STATUS_LEDS COLOR="CALIBRATING_Z"
     {% endif %}
 
@@ -34,6 +34,6 @@ gcode:
         _BASE_CALIBRATE_Z BED_POSITION="{ZRPx},{ZRPy}"
     {% endif %}
 
-    {% if status_leds_enabled %}
+    {% if neopixel_leds_enabled %}
         STATUS_LEDS COLOR="READY"
     {% endif %}

--- a/macros/base/probing/overrides/qgl.cfg
+++ b/macros/base/probing/overrides/qgl.cfg
@@ -8,7 +8,7 @@ rename_existing: _BASE_QUAD_GANTRY_LEVEL
 description: Conform a moving, twistable gantry to the shape of a stationary bed with klicky automount
 gcode:
     {% set tilting_travel_accel = printer["gcode_macro _USER_VARIABLES"].tilting_travel_accel %}
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set neopixel_leds_enabled = printer["gcode_macro _USER_VARIABLES"].neopixel_leds_enabled %}
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
 
     {% if verbose %}
@@ -17,7 +17,7 @@ gcode:
 
     _CG28
     
-    {% if status_leds_enabled %}
+    {% if neopixel_leds_enabled %}
         STATUS_LEDS COLOR="LEVELING"
     {% endif %}
 
@@ -35,6 +35,6 @@ gcode:
 
     DEACTIVATE_PROBE
 
-    {% if status_leds_enabled %}
+    {% if neopixel_leds_enabled %}
         STATUS_LEDS COLOR="READY"
     {% endif %}

--- a/macros/base/probing/overrides/z_tilt.cfg
+++ b/macros/base/probing/overrides/z_tilt.cfg
@@ -8,7 +8,7 @@ rename_existing: _BASE_Z_TILT_ADJUST
 description: Conform a moving bed to the shape of a stationary gantry with dockable probe automount
 gcode:
     {% set tilting_travel_accel = printer["gcode_macro _USER_VARIABLES"].tilting_travel_accel %}
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set neopixel_leds_enabled = printer["gcode_macro _USER_VARIABLES"].neopixel_leds_enabled %}
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
 
 
@@ -18,7 +18,7 @@ gcode:
     
     _CG28
 
-    {% if status_leds_enabled %}
+    {% if neopixel_leds_enabled %}
         STATUS_LEDS COLOR="LEVELING"
     {% endif %}
 
@@ -36,6 +36,6 @@ gcode:
 
     DEACTIVATE_PROBE
 
-    {% if status_leds_enabled %}
+    {% if neopixel_leds_enabled %}
         STATUS_LEDS COLOR="READY"
     {% endif %}

--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -57,7 +57,7 @@ gcode:
     {% set light_enabled = printer["gcode_macro _USER_VARIABLES"].light_enabled %}
     {% set light_intensity_start_print = printer["gcode_macro _USER_VARIABLES"].light_intensity_start_print %}
     {% set light_intensity_printing = printer["gcode_macro _USER_VARIABLES"].light_intensity_printing %}
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set neopixel_leds_enabled = printer["gcode_macro _USER_VARIABLES"].neopixel_leds_enabled %}
     {% set force_homing_in_start_print = printer["gcode_macro _USER_VARIABLES"].force_homing_in_start_print %}
     {% set klippain_mmu_enabled = printer["gcode_macro _USER_VARIABLES"].klippain_mmu_enabled %}
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
@@ -79,7 +79,7 @@ gcode:
     # --------------------------------
     # Let's do the START_PRINT actions
     # --------------------------------
-    {% if status_leds_enabled %}
+    {% if neopixel_leds_enabled %}
         STATUS_LEDS COLOR="BUSY"
     {% endif %}
 
@@ -200,7 +200,7 @@ gcode:
     {% endif %}
 
     # And.... Goooo!
-    {% if status_leds_enabled %}
+    {% if neopixel_leds_enabled %}
         STATUS_LEDS COLOR="PRINTING"
     {% endif %}
 
@@ -245,7 +245,7 @@ gcode:
     {% set SOAK = printer["gcode_macro START_PRINT"].soak %}
     {% set CHAMBER_TEMP = printer["gcode_macro START_PRINT"].chamber_temp %}
 
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set neopixel_leds_enabled = printer["gcode_macro _USER_VARIABLES"].neopixel_leds_enabled %}
     {% set filter_enabled = printer["gcode_macro _USER_VARIABLES"].filter_enabled %}
 
     {% set St = printer["gcode_macro _USER_VARIABLES"].travel_speed * 60 %}
@@ -253,7 +253,7 @@ gcode:
     {% set max_x = printer.toolhead.axis_maximum.x|float %}
     {% set max_y = printer.toolhead.axis_maximum.y|float %}
 
-    {% if status_leds_enabled %}
+    {% if neopixel_leds_enabled %}
         STATUS_LEDS COLOR="HEATING"
     {% endif %}
 
@@ -335,7 +335,7 @@ gcode:
     {% set INITIAL_TOOL = printer["gcode_macro START_PRINT"].initial_tool %}
 
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set neopixel_leds_enabled = printer["gcode_macro _USER_VARIABLES"].neopixel_leds_enabled %}
     {% set klippain_mmu_enabled = printer["gcode_macro _USER_VARIABLES"].klippain_mmu_enabled %}
     {% set purge_and_brush_enabled = printer["gcode_macro _USER_VARIABLES"].purge_and_brush_enabled %}
     {% set purgeclean_servo_enabled = printer["gcode_macro _USER_VARIABLES"].purgeclean_servo_enabled %}
@@ -346,7 +346,7 @@ gcode:
     {% set max_x = printer.toolhead.axis_maximum.x|float %}
     {% set max_y = printer.toolhead.axis_maximum.y|float %}
 
-    {% if status_leds_enabled %}
+    {% if neopixel_leds_enabled %}
         STATUS_LEDS COLOR="HEATING"
     {% endif %}
 
@@ -429,7 +429,7 @@ gcode:
 
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set neopixel_leds_enabled = printer["gcode_macro _USER_VARIABLES"].neopixel_leds_enabled %}
 
     {% if bed_mesh_enabled %}
         {% if BED_MESH_PROFILE == "" %}
@@ -450,11 +450,11 @@ gcode:
 gcode:
     # Preheat the nozzle to safe probing temperature.
     {% set safe_extruder_temp = printer["gcode_macro _USER_VARIABLES"].safe_extruder_temp|float %}
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set neopixel_leds_enabled = printer["gcode_macro _USER_VARIABLES"].neopixel_leds_enabled %}
     {% set probe_type_enabled = printer["gcode_macro _USER_VARIABLES"].probe_type_enabled %}
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
 
-    {% if status_leds_enabled %}
+    {% if neopixel_leds_enabled %}
         STATUS_LEDS COLOR="HEATING"
     {% endif %}
     {% if verbose %}

--- a/macros/hardware_functions/status_leds.cfg
+++ b/macros/hardware_functions/status_leds.cfg
@@ -201,7 +201,7 @@ gcode:
         { action_raise_error("COLOR is not valid!") }
     {% endif %}
 
-    {% if printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% if printer["gcode_macro _USER_VARIABLES"].neopixel_leds_enabled %}
         {% if printer["gcode_macro _USER_VARIABLES"].status_leds_effects_enabled == False %}
             _SET_LEDS_BY_NAME LEDS="logo" COLOR={status_color[color].logo} TRANSMIT={logo_transmit}
             _SET_LEDS_BY_NAME LEDS="nozzle" COLOR={status_color[color].nozzle} TRANSMIT=1

--- a/macros/helpers/nozzle_cleaning.cfg
+++ b/macros/helpers/nozzle_cleaning.cfg
@@ -3,7 +3,7 @@ description: Wipe the nozzle on the brush
 gcode:
     {% set purge_and_brush_enabled = printer["gcode_macro _USER_VARIABLES"].purge_and_brush_enabled %}
     {% set purgeclean_servo_enabled = printer["gcode_macro _USER_VARIABLES"].purgeclean_servo_enabled %}
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set neopixel_leds_enabled = printer["gcode_macro _USER_VARIABLES"].neopixel_leds_enabled %}
     {% set brush_clean_accel = printer["gcode_macro _USER_VARIABLES"].brush_clean_accel %}
     {% set brush_over_y_axis = printer["gcode_macro _USER_VARIABLES"].brush_over_y_axis %}
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
@@ -15,7 +15,7 @@ gcode:
 
         {% set Bx, By, Bz = printer["gcode_macro _USER_VARIABLES"].brush_xyz|map('float') %}
 
-        {% if status_leds_enabled %}
+        {% if neopixel_leds_enabled %}
             STATUS_LEDS COLOR="CLEANING"
         {% endif %}
 
@@ -60,7 +60,7 @@ gcode:
         {% endif %}
     {% endif %}
 
-    {% if status_leds_enabled %}
+    {% if neopixel_leds_enabled %}
         STATUS_LEDS COLOR="READY"
     {% endif %}
 
@@ -75,7 +75,7 @@ gcode:
 
     {% set purge_and_brush_enabled = printer["gcode_macro _USER_VARIABLES"].purge_and_brush_enabled %}
     {% set purgeclean_servo_enabled = printer["gcode_macro _USER_VARIABLES"].purgeclean_servo_enabled %}
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set neopixel_leds_enabled = printer["gcode_macro _USER_VARIABLES"].neopixel_leds_enabled %}
     {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
     {% set re_enable_filament_sensor = 0 %}
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
@@ -84,7 +84,7 @@ gcode:
         {% set St = printer["gcode_macro _USER_VARIABLES"].travel_speed * 60 %}
         {% set Sz = printer["gcode_macro _USER_VARIABLES"].z_drop_speed * 60 %}
         
-        {% if status_leds_enabled %}
+        {% if neopixel_leds_enabled %}
             STATUS_LEDS COLOR="CLEANING"
         {% endif %}
         
@@ -127,7 +127,7 @@ gcode:
         {% endif %}
     {% endif %}
 
-    {% if status_leds_enabled %}
+    {% if neopixel_leds_enabled %}
         STATUS_LEDS COLOR="READY"
     {% endif %}
 

--- a/macros/miscs/startup.cfg
+++ b/macros/miscs/startup.cfg
@@ -57,7 +57,7 @@ gcode:
 
 [gcode_macro _INIT_LEDS]
 gcode:
-    {% if printer["gcode_macro _USER_VARIABLES"].status_leds_enabled or printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
+    {% if printer["gcode_macro _USER_VARIABLES"].neopixel_leds_enabled %}
         {% if printer["gcode_macro _USER_VARIABLES"].caselight_on_at_startup|default(False) %}
             STATUS_LEDS COLOR="READY"
         {% else %}


### PR DESCRIPTION
if no toolhead light is selected in printer.cfg and only one of the 2 types of neopixel caselight is included then no lighting will be active in the macros.