### PR TITLE
Option to use RGB caselights as status LEDs

### DIFF
--- a/macros/base/cancel_print.cfg
+++ b/macros/base/cancel_print.cfg
@@ -10,6 +10,7 @@ gcode:
     {% set filter_enabled = printer["gcode_macro _USER_VARIABLES"].filter_enabled %}
     {% set light_enabled = printer["gcode_macro _USER_VARIABLES"].light_enabled %}
     {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set status_leds_caselight_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
     {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
     {% set filter_default_time = printer["gcode_macro _USER_VARIABLES"].filter_default_time_on_end_print|default(600)|int %}
@@ -62,7 +63,7 @@ gcode:
     {% if light_enabled %}
         LIGHT_ON S={light_intensity_end_print}
     {% endif %}
-    {% if status_leds_enabled %}
+    {% if status_leds_enabled or status_leds_caselight_enabled %}
         STATUS_LEDS COLOR="OFF"
     {% endif %}
 

--- a/macros/base/control.cfg
+++ b/macros/base/control.cfg
@@ -2,7 +2,8 @@
 description: Turn off the printer
 gcode:
     {% set light_enabled = printer["gcode_macro _USER_VARIABLES"].light_enabled %}
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %} 
+    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set status_leds_caselight_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
     {% set display_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_minidisplay_enabled %}
     M84                                                             ; turn steppers off
     TURN_OFF_HEATERS                                                ; turn bed / hotend off
@@ -10,7 +11,7 @@ gcode:
     {% if light_enabled %}
         LIGHT_OFF                                                   ; turn off light
     {% endif %}
-    {% if status_leds_enabled %}
+    {% if status_leds_enabled or status_leds_caselight_enabled %}
         STATUS_LEDS COLOR="SHUTDOWN"                                     ; turn off status LEDs
     {% endif %}
     {% if display_leds_enabled %}

--- a/macros/base/end_print.cfg
+++ b/macros/base/end_print.cfg
@@ -10,6 +10,7 @@ gcode:
     {% set filter_enabled = printer["gcode_macro _USER_VARIABLES"].filter_enabled %}
     {% set light_enabled = printer["gcode_macro _USER_VARIABLES"].light_enabled %}
     {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set status_leds_caselight_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
     {% set filter_default_time = printer["gcode_macro _USER_VARIABLES"].filter_default_time_on_end_print|default(600)|int %}
     {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
@@ -63,7 +64,7 @@ gcode:
     {% if light_enabled %}
         LIGHT_ON S={light_intensity_end_print}
     {% endif %}
-    {% if status_leds_enabled %}
+    {% if status_leds_enabled or status_leds_caselight_enabled %}
         STATUS_LEDS COLOR="DONE_PRINTING"
     {% endif %}
 

--- a/macros/base/homing/homing_conditional.cfg
+++ b/macros/base/homing/homing_conditional.cfg
@@ -2,13 +2,14 @@
 description: Homing only if necessary
 gcode:
     {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set status_leds_caselight_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
 
     {% if "xyz" not in printer.toolhead.homed_axes %}
-        {% if status_leds_enabled %}
+        {% if status_leds_enabled or status_leds_caselight_enabled%}
             STATUS_LEDS COLOR="HOMING"
         {% endif %}
         G28
-        {% if status_leds_enabled %}
+        {% if status_leds_enabled or status_leds_caselight_enabled%}
             STATUS_LEDS COLOR="READY"
         {% endif %}  
     {% endif %}

--- a/macros/base/homing/homing_override.cfg
+++ b/macros/base/homing/homing_override.cfg
@@ -15,6 +15,7 @@ gcode:
     {% set z_driver = printer["gcode_macro _USER_VARIABLES"].z_driver %}
     {% set z_drop_speed = printer["gcode_macro _USER_VARIABLES"].z_drop_speed * 60 %}
     {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set status_leds_caselight_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
 
     {% set homing_first = printer["gcode_macro _USER_VARIABLES"].homing_first|string|upper %}
@@ -33,7 +34,7 @@ gcode:
     # reset parameters
     {% set X, Y, Z = False, False, False %}
 
-    {% if status_leds_enabled %}
+    {% if status_leds_enabled or status_leds_caselight_enabled %}
         STATUS_LEDS COLOR="HOMING"
     {% endif %}
 
@@ -345,7 +346,7 @@ gcode:
         _EXIT_POINT FUNCTION=homing_override
     {% endif %}
 
-    {% if status_leds_enabled %}
+    {% if status_leds_enabled or status_leds_caselight_enabled %}
         STATUS_LEDS COLOR="READY"
     {% endif %}
 

--- a/macros/base/homing/z_calibration.cfg
+++ b/macros/base/homing/z_calibration.cfg
@@ -5,8 +5,9 @@ gcode:
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
     {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set status_leds_caselight_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
 
-    {% if status_leds_enabled %}
+    {% if status_leds_enabled or status_leds_caselight_enabled %}
         STATUS_LEDS COLOR="CALIBRATING_Z"
     {% endif %}
 
@@ -34,6 +35,6 @@ gcode:
         _BASE_CALIBRATE_Z BED_POSITION="{ZRPx},{ZRPy}"
     {% endif %}
 
-    {% if status_leds_enabled %}
+    {% if status_leds_enabled or status_leds_caselight_enabled %}
         STATUS_LEDS COLOR="READY"
     {% endif %}

--- a/macros/base/probing/overrides/qgl.cfg
+++ b/macros/base/probing/overrides/qgl.cfg
@@ -9,6 +9,7 @@ description: Conform a moving, twistable gantry to the shape of a stationary bed
 gcode:
     {% set tilting_travel_accel = printer["gcode_macro _USER_VARIABLES"].tilting_travel_accel %}
     {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set status_leds_caselight_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
 
     {% if verbose %}
@@ -17,7 +18,7 @@ gcode:
 
     _CG28
     
-    {% if status_leds_enabled %}
+    {% if status_leds_enabled or status_leds_caselight_enabled %}
         STATUS_LEDS COLOR="LEVELING"
     {% endif %}
 
@@ -34,6 +35,6 @@ gcode:
 
     DEACTIVATE_PROBE
 
-    {% if status_leds_enabled %}
+    {% if status_leds_enabled or status_leds_caselight_enabled %}
         STATUS_LEDS COLOR="READY"
     {% endif %}

--- a/macros/base/probing/overrides/z_tilt.cfg
+++ b/macros/base/probing/overrides/z_tilt.cfg
@@ -9,6 +9,7 @@ description: Conform a moving bed to the shape of a stationary gantry with docka
 gcode:
     {% set tilting_travel_accel = printer["gcode_macro _USER_VARIABLES"].tilting_travel_accel %}
     {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set status_leds_caselight_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
 
 
@@ -18,7 +19,7 @@ gcode:
     
     _CG28
 
-    {% if status_leds_enabled %}
+    {% if status_leds_enabled or status_leds_caselight_enabled %}
         STATUS_LEDS COLOR="LEVELING"
     {% endif %}
 
@@ -35,6 +36,6 @@ gcode:
 
     DEACTIVATE_PROBE
 
-    {% if status_leds_enabled %}
+    {% if status_leds_enabled or status_leds_caselight_enabled %}
         STATUS_LEDS COLOR="READY"
     {% endif %}

--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -58,6 +58,7 @@ gcode:
     {% set light_intensity_start_print = printer["gcode_macro _USER_VARIABLES"].light_intensity_start_print %}
     {% set light_intensity_printing = printer["gcode_macro _USER_VARIABLES"].light_intensity_printing %}
     {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set status_leds_caselight_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
     {% set force_homing_in_start_print = printer["gcode_macro _USER_VARIABLES"].force_homing_in_start_print %}
     {% set klippain_mmu_enabled = printer["gcode_macro _USER_VARIABLES"].klippain_mmu_enabled %}
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
@@ -79,7 +80,7 @@ gcode:
     # --------------------------------
     # Let's do the START_PRINT actions
     # --------------------------------
-    {% if status_leds_enabled %}
+    {% if status_leds_enabled or status_leds_caselight_enabled %}
         STATUS_LEDS COLOR="BUSY"
     {% endif %}
 
@@ -188,7 +189,7 @@ gcode:
     {% endif %}
 
     # And.... Goooo!
-    {% if status_leds_enabled %}
+    {% if status_leds_enabled or status_leds_caselight_enabled %}
         STATUS_LEDS COLOR="PRINTING"
     {% endif %}
 
@@ -234,6 +235,7 @@ gcode:
     {% set CHAMBER_TEMP = printer["gcode_macro START_PRINT"].chamber_temp %}
 
     {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set status_leds_caselight_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
     {% set filter_enabled = printer["gcode_macro _USER_VARIABLES"].filter_enabled %}
 
     {% set St = printer["gcode_macro _USER_VARIABLES"].travel_speed * 60 %}
@@ -241,7 +243,7 @@ gcode:
     {% set max_x = printer.toolhead.axis_maximum.x|float %}
     {% set max_y = printer.toolhead.axis_maximum.y|float %}
 
-    {% if status_leds_enabled %}
+    {% if status_leds_enabled or status_leds_caselight_enabled %}
         STATUS_LEDS COLOR="HEATING"
     {% endif %}
 
@@ -324,6 +326,7 @@ gcode:
 
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
     {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set status_leds_caselight_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
     {% set klippain_mmu_enabled = printer["gcode_macro _USER_VARIABLES"].klippain_mmu_enabled %}
     {% set purge_and_brush_enabled = printer["gcode_macro _USER_VARIABLES"].purge_and_brush_enabled %}
     {% set purgeclean_servo_enabled = printer["gcode_macro _USER_VARIABLES"].purgeclean_servo_enabled %}
@@ -334,7 +337,7 @@ gcode:
     {% set max_x = printer.toolhead.axis_maximum.x|float %}
     {% set max_y = printer.toolhead.axis_maximum.y|float %}
 
-    {% if status_leds_enabled %}
+    {% if status_leds_enabled or status_leds_caselight_enabled %}
         STATUS_LEDS COLOR="HEATING"
     {% endif %}
 
@@ -418,6 +421,7 @@ gcode:
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
     {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set status_leds_caselight_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
 
     {% if bed_mesh_enabled %}
         {% if BED_MESH_PROFILE == "" %}
@@ -439,10 +443,11 @@ gcode:
     # Preheat the nozzle to safe probing temperature.
     {% set safe_extruder_temp = printer["gcode_macro _USER_VARIABLES"].safe_extruder_temp|float %}
     {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set status_leds_caselight_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
     {% set probe_type_enabled = printer["gcode_macro _USER_VARIABLES"].probe_type_enabled %}
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
 
-    {% if status_leds_enabled %}
+    {% if status_leds_enabled or status_leds_caselight_enabled %}
         STATUS_LEDS COLOR="HEATING"
     {% endif %}
     {% if verbose %}

--- a/macros/helpers/nozzle_cleaning.cfg
+++ b/macros/helpers/nozzle_cleaning.cfg
@@ -4,6 +4,7 @@ gcode:
     {% set purge_and_brush_enabled = printer["gcode_macro _USER_VARIABLES"].purge_and_brush_enabled %}
     {% set purgeclean_servo_enabled = printer["gcode_macro _USER_VARIABLES"].purgeclean_servo_enabled %}
     {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set status_leds_caselight_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
     {% set brush_clean_accel = printer["gcode_macro _USER_VARIABLES"].brush_clean_accel %}
     {% set brush_over_y_axis = printer["gcode_macro _USER_VARIABLES"].brush_over_y_axis %}
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
@@ -15,7 +16,7 @@ gcode:
 
         {% set Bx, By, Bz = printer["gcode_macro _USER_VARIABLES"].brush_xyz|map('float') %}
 
-        {% if status_leds_enabled %}
+        {% if status_leds_enabled or status_leds_caselight_enabled %}
             STATUS_LEDS COLOR="CLEANING"
         {% endif %}
 
@@ -59,7 +60,7 @@ gcode:
         {% endif %}
     {% endif %}
 
-    {% if status_leds_enabled %}
+    {% if status_leds_enabled or status_leds_caselight_enabled %}
         STATUS_LEDS COLOR="READY"
     {% endif %}
 
@@ -75,6 +76,7 @@ gcode:
     {% set purge_and_brush_enabled = printer["gcode_macro _USER_VARIABLES"].purge_and_brush_enabled %}
     {% set purgeclean_servo_enabled = printer["gcode_macro _USER_VARIABLES"].purgeclean_servo_enabled %}
     {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set status_leds_caselight_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
     {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
     {% set re_enable_filament_sensor = 0 %}
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
@@ -83,7 +85,7 @@ gcode:
         {% set St = printer["gcode_macro _USER_VARIABLES"].travel_speed * 60 %}
         {% set Sz = printer["gcode_macro _USER_VARIABLES"].z_drop_speed * 60 %}
         
-        {% if status_leds_enabled %}
+        {% if status_leds_enabled or status_leds_caselight_enabled %}
             STATUS_LEDS COLOR="CLEANING"
         {% endif %}
         
@@ -126,7 +128,7 @@ gcode:
         {% endif %}
     {% endif %}
 
-    {% if status_leds_enabled %}
+    {% if status_leds_enabled or status_leds_caselight_enabled %}
         STATUS_LEDS COLOR="READY"
     {% endif %}
 

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -237,6 +237,9 @@ variable_light_intensity_end_print: 0
 ## Caselight LEDs ON at startup (caselight need to be installed in the machine)
 variable_caselight_on_at_startup: False
 
+## Caselight RGB used as status LEDs
+variable_status_leds_caselight_enabled: false
+
 ## Patch the M190/M109 commands to avoid some wait time while the temperature
 ## settle on very low thermal latency devices (such as the BambuLabs hotend)
 variable_fix_heaters_temperature_settle: False


### PR DESCRIPTION
Modified calls to gcode macro STATUS_LED to also execute if user variable status_leds_caselight_enabled is true.

Also added variable status_leds_caselight_enabled to user variables file. If user sets this to true, then caselights will function as status LEDs. If set to false, then caselights will illuminate to their initial colors as called out in [neopixel caselight], but won't function as status LEDs.

(This is my first ever pull request on github - I hope I did it right.)