### PR TITLE
Enable case lighting with caselight_on_at_startup

### DIFF
--- a/macros/miscs/startup.cfg
+++ b/macros/miscs/startup.cfg
@@ -59,8 +59,14 @@ gcode:
 gcode:
     {% if printer["gcode_macro _USER_VARIABLES"].status_leds_enabled or printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
         {% if printer["gcode_macro _USER_VARIABLES"].caselight_on_at_startup|default(False) %}
+            {% if printer["gcode_macro _USER_VARIABLES"].light_enabled %}
+                LIGHT_ON
+            {% endif %}
             STATUS_LEDS COLOR="READY"
         {% else %}
+            {% if printer["gcode_macro _USER_VARIABLES"].light_enabled %}
+                LIGHT_OFF
+            {% endif %}
             STATUS_LEDS COLOR="OFF"
         {% endif %}
     {% endif %}


### PR DESCRIPTION
Using white caselights `fcob_white`, only the status lights on toolhead are enabled with the `caselight_on_at_startup` variable set to `True`.

This change turns on caselights using `LIGHT_ON`/`LIGHT_OFF` macros