### PR TITLE
Cartographer probe config

### DIFF
--- a/config/hardware/accelerometers/cartographer_lis2dw.cfg
+++ b/config/hardware/accelerometers/cartographer_lis2dw.cfg
@@ -1,0 +1,13 @@
+[lis2dw]
+cs_pin: cartographer:PA3
+spi_bus: spi1
+
+[resonance_tester]
+accel_chip: lis2dw
+probe_points:
+    125, 125, 20
+
+# Include the IS calibration macros to unlock them when
+# an accelerometer is installed on the machine
+[include ../../../macros/helpers/resonance_override.cfg]
+[include ../../../scripts/K-ShakeTune/K-SnT_*.cfg]

--- a/config/hardware/probes/cartographer_virtual.cfg
+++ b/config/hardware/probes/cartographer_virtual.cfg
@@ -18,46 +18,46 @@
 #   If you are using the CAN Bus version, replace serial: with canbus_uuid: and add the UUID.
 #   Example: canbus_uuid: 1283as878a9sd
 #
-# These settings are based on a Voron 2.4r2 300mm with the Cartographer CNC mount.  Edit in overrides.cfg as appropriate for your configuration
-#speed: 40.
+# These settings are the defaults from Cartographer, edit as needed in your overrides.cfg
+speed: 40.
 #   Z probing dive speed.
-#lift_speed: 5.
+lift_speed: 5.
 #   Z probing lift speed.
-#backlash_comp: 0.5
+backlash_comp: 0.5
 #   Backlash compensation distance for removing Z backlash before measuring
 #   the sensor response.
-#x_offset: 0.
+x_offset: 0.
 #   X offset of cartographer from the nozzle.
-#y_offset: 21.1
+y_offset: 21.1
 #   Y offset of cartographer from the nozzle.
-#trigger_distance: 2.
+trigger_distance: 2.
 #   cartographer trigger distance for homing.
-#trigger_dive_threshold: 1.5
+trigger_dive_threshold: 1.5
 #   Threshold for range vs dive mode probing. Beyond `trigger_distance +
 #   trigger_dive_threshold` a dive will be used.
-#trigger_hysteresis: 0.006
+trigger_hysteresis: 0.006
 #   Hysteresis on trigger threshold for untriggering, as a percentage of the
 #   trigger threshold.
-#cal_nozzle_z: 0.1
+cal_nozzle_z: 0.1
 #   Expected nozzle offset after completing manual Z offset calibration.
-#cal_floor: 0.1
+cal_floor: 0.1
 #   Minimum z bound on sensor response measurement.
-#cal_ceil:5.
+cal_ceil:5.
 #   Maximum z bound on sensor response measurement.
-#cal_speed: 1.0
+cal_speed: 1.0
 #   Speed while measuring response curve.
-#cal_move_speed: 10.
+cal_move_speed: 10.
 #   Speed while moving to position for response curve measurement.
-#default_model_name: default
+default_model_name: default
 #   Name of default cartographer model to load.
-#mesh_main_direction: x
+mesh_main_direction: x
 #   Primary travel direction during mesh measurement.
 #mesh_overscan: -1
 #   Distance to use for direction changes at mesh line ends. Omit this setting
 #   and a default will be calculated from line spacing and available travel.
-#mesh_cluster_size: 1
+mesh_cluster_size: 1
 #   Radius of mesh grid point clusters.
-#mesh_runs: 2
+mesh_runs: 2
 #   Number of passes to make during mesh scan.
 
 [safe_z_home]

--- a/config/hardware/probes/cartographer_virtual.cfg
+++ b/config/hardware/probes/cartographer_virtual.cfg
@@ -18,45 +18,46 @@
 #   If you are using the CAN Bus version, replace serial: with canbus_uuid: and add the UUID.
 #   Example: canbus_uuid: 1283as878a9sd
 #
-speed: 40.
+# These settings are based on a Voron 2.4r2 300mm with the Cartographer CNC mount.  Edit in overrides.cfg as appropriate for your configuration
+#speed: 40.
 #   Z probing dive speed.
-lift_speed: 5.
+#lift_speed: 5.
 #   Z probing lift speed.
-backlash_comp: 0.5
+#backlash_comp: 0.5
 #   Backlash compensation distance for removing Z backlash before measuring
 #   the sensor response.
-x_offset: 0.
+#x_offset: 0.
 #   X offset of cartographer from the nozzle.
-y_offset: 21.1
+#y_offset: 21.1
 #   Y offset of cartographer from the nozzle.
-trigger_distance: 2.
+#trigger_distance: 2.
 #   cartographer trigger distance for homing.
-trigger_dive_threshold: 1.5
+#trigger_dive_threshold: 1.5
 #   Threshold for range vs dive mode probing. Beyond `trigger_distance +
 #   trigger_dive_threshold` a dive will be used.
-trigger_hysteresis: 0.006
+#trigger_hysteresis: 0.006
 #   Hysteresis on trigger threshold for untriggering, as a percentage of the
 #   trigger threshold.
-cal_nozzle_z: 0.1
+#cal_nozzle_z: 0.1
 #   Expected nozzle offset after completing manual Z offset calibration.
-cal_floor: 0.1
+#cal_floor: 0.1
 #   Minimum z bound on sensor response measurement.
-cal_ceil:5.
+#cal_ceil:5.
 #   Maximum z bound on sensor response measurement.
-cal_speed: 1.0
+#cal_speed: 1.0
 #   Speed while measuring response curve.
-cal_move_speed: 10.
+#cal_move_speed: 10.
 #   Speed while moving to position for response curve measurement.
-default_model_name: default
+#default_model_name: default
 #   Name of default cartographer model to load.
-mesh_main_direction: x
+#mesh_main_direction: x
 #   Primary travel direction during mesh measurement.
 #mesh_overscan: -1
 #   Distance to use for direction changes at mesh line ends. Omit this setting
 #   and a default will be calculated from line spacing and available travel.
-mesh_cluster_size: 1
+#mesh_cluster_size: 1
 #   Radius of mesh grid point clusters.
-mesh_runs: 2
+#mesh_runs: 2
 #   Number of passes to make during mesh scan.
 
 [safe_z_home]

--- a/config/hardware/probes/cartographer_virtual.cfg
+++ b/config/hardware/probes/cartographer_virtual.cfg
@@ -1,0 +1,78 @@
+# This probe type is for a Cartographer probe used directly as a virtual Z endstop
+# rather than with an existing physical endstop. To use this configuration,
+# you will need to manually add the Cartographer Klipper plugin!
+
+## Then, you should just add the following two lines to your overrides and everything should work!
+#[cartographer]
+#   Path to the serial port for the Cartographer device. Typically has the form
+#   /dev/serial/by-id/usb-cartographer_cartographer_...
+#   
+#   If you are using the CAN Bus version, replace serial: with canbus_uuid: and add the UUID.
+#   Example: canbus_uuid: 1283as878a9sd
+#
+
+[cartographer]
+#   Path to the serial port for the Cartographer device. Typically has the form
+#   /dev/serial/by-id/usb-cartographer_cartographer_...
+#   
+#   If you are using the CAN Bus version, replace serial: with canbus_uuid: and add the UUID.
+#   Example: canbus_uuid: 1283as878a9sd
+#
+speed: 40.
+#   Z probing dive speed.
+lift_speed: 5.
+#   Z probing lift speed.
+backlash_comp: 0.5
+#   Backlash compensation distance for removing Z backlash before measuring
+#   the sensor response.
+x_offset: 0.
+#   X offset of cartographer from the nozzle.
+y_offset: 21.1
+#   Y offset of cartographer from the nozzle.
+trigger_distance: 2.
+#   cartographer trigger distance for homing.
+trigger_dive_threshold: 1.5
+#   Threshold for range vs dive mode probing. Beyond `trigger_distance +
+#   trigger_dive_threshold` a dive will be used.
+trigger_hysteresis: 0.006
+#   Hysteresis on trigger threshold for untriggering, as a percentage of the
+#   trigger threshold.
+cal_nozzle_z: 0.1
+#   Expected nozzle offset after completing manual Z offset calibration.
+cal_floor: 0.1
+#   Minimum z bound on sensor response measurement.
+cal_ceil:5.
+#   Maximum z bound on sensor response measurement.
+cal_speed: 1.0
+#   Speed while measuring response curve.
+cal_move_speed: 10.
+#   Speed while moving to position for response curve measurement.
+default_model_name: default
+#   Name of default cartographer model to load.
+mesh_main_direction: x
+#   Primary travel direction during mesh measurement.
+#mesh_overscan: -1
+#   Distance to use for direction changes at mesh line ends. Omit this setting
+#   and a default will be calculated from line spacing and available travel.
+mesh_cluster_size: 1
+#   Radius of mesh grid point clusters.
+mesh_runs: 2
+#   Number of passes to make during mesh scan.
+
+[safe_z_home]
+home_xy_position: 150,150
+# Example home_xy_position: 175,175 - This would be for a 350 * 350mm bed. 
+z_hop: 10
+
+[gcode_macro _USER_VARIABLES]
+# We can declare an "inductive_virtual" probe type as it's pretty close to the Cartographer way of working and should just work!
+variable_probe_type_enabled: "inductive_virtual"
+gcode:
+
+# Cartographer probe definition also include the probe management macro directly from here
+[include ../../../macros/base/probing/generic_probe.cfg]
+
+# Z Stepper overrides for Cartographer
+[stepper_z]
+endstop_pin: probe:z_virtual_endstop # use cartographer as virtual endstop
+homing_retract_dist: 0 # cartographer needs this to be set to 0

--- a/config/hardware/probes/cartographer_virtual.cfg
+++ b/config/hardware/probes/cartographer_virtual.cfg
@@ -73,7 +73,11 @@ gcode:
 # Cartographer probe definition also include the probe management macro directly from here
 [include ../../../macros/base/probing/generic_probe.cfg]
 
+# PROBE_CALIBRATE macro as per the cartographer docs
+[include ../../../macros/base/probing/cartographer.cfg]
+
 # Z Stepper overrides for Cartographer
 [stepper_z]
 endstop_pin: probe:z_virtual_endstop # use cartographer as virtual endstop
 homing_retract_dist: 0 # cartographer needs this to be set to 0
+

--- a/macros/base/probing/cartographer.cfg
+++ b/macros/base/probing/cartographer.cfg
@@ -1,0 +1,3 @@
+[gcode_macro PROBE_CALIBRATE]
+gcode:
+    CARTOGRAPHER_CALIBRATE

--- a/moonraker/cartographer_probe.conf
+++ b/moonraker/cartographer_probe.conf
@@ -1,0 +1,13 @@
+# Cartographer code
+[update_manager cartographer]
+type: git_repo
+path: ~/cartographer-klipper
+channel: dev
+origin: https://github.com/Cartographer3D/cartographer-klipper.git
+env: ~/klippy-env/bin/python
+requirements: requirements.txt
+install_script: install.sh
+is_system_service: False
+managed_services: klipper
+info_tags:
+  desc=Cartographer Probe

--- a/user_templates/moonraker.conf
+++ b/user_templates/moonraker.conf
@@ -46,6 +46,9 @@
 # [include moonraker/tmc_autotune.conf]
 # -----------------------------------------------------------------
 
+##### Cartographer plugin update management  ----------------------
+# [include moonraker/cartographer_probe.conf]
+# -----------------------------------------------------------------
 
 ##### Add your custom moonraker config customizations and overrides below this line...
 # ------------------------------------------------------------------------------------

--- a/user_templates/printer.cfg
+++ b/user_templates/printer.cfg
@@ -106,6 +106,9 @@
 
 ## Beacon probe also used as virtual Z endstop. Do not forget to install the plugin and add the [beacon] section to make it work!
 # [include config/hardware/probes/beacon_virtual.cfg]
+
+## Cartographer probe also used as virtual Z endstop. Do not forget to install the plugin and add the [cartographer] section to make it work!
+# [include config/hardware/probes/cartographer_virtual.cfg]
 # ----------------------------------------------------------------------------------------
 
 

--- a/user_templates/printer.cfg
+++ b/user_templates/printer.cfg
@@ -206,6 +206,8 @@
 # [include config/hardware/accelerometers/lis2dw_usb_rp2040_spi1.cfg] # For BTT S2DW V1.0, ... 
 
 # [include config/hardware/accelerometers/beacon_accelerometer.cfg] # For Beacon Rev H make sure Beacon. Do not forget to include the beacon_virtual_probe in the PROBE section!
+
+# [include config/hardware/accelerometers/cartographer_accelerometer.cfg] # For Cartographer lis2dw.
 # ----------------------------------------------------------------------------------------
 
 

--- a/user_templates/printer.cfg
+++ b/user_templates/printer.cfg
@@ -107,7 +107,8 @@
 ## Beacon probe also used as virtual Z endstop. Do not forget to install the plugin and add the [beacon] section to make it work!
 # [include config/hardware/probes/beacon_virtual.cfg]
 
-## Cartographer probe also used as virtual Z endstop. Do not forget to install the plugin and add the [cartographer] section to make it work!
+## Cartographer probe also used as virtual Z endstop. Do not forget to install the plugin and add the [cartographer] section to overrides.cfg make it work!
+## See the below file for available options
 # [include config/hardware/probes/cartographer_virtual.cfg]
 # ----------------------------------------------------------------------------------------
 


### PR DESCRIPTION
This is an attempt to add the Cartographer eddy sensor probe to Klippain in the same style as the Beacon probe.

This config is tested and works on my Voron 2.4r2 300mm.