### PR TITLE
added a fix for filament sensor activation for material as default

### DIFF
--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -73,9 +73,11 @@ gcode:
     {% else %}
         RESPOND MSG="Material '{MATERIAL}' is used"
         {% set material = printer["gcode_macro _USER_VARIABLES"].material_parameters[MATERIAL] %}
+        {% if filament_sensor_enabled %}
+            {% set filament_sensor_enabled = material.filament_sensor | default(1) %}
+        {% endif %}
     {% endif %}
-
-
+    
     # --------------------------------
     # Let's do the START_PRINT actions
     # --------------------------------
@@ -195,7 +197,7 @@ gcode:
         START_FILTER SPEED={material.filter_speed / 100}
     {% endif %}
 
-    {% if filament_sensor_enabled and not material.filament_sensor %}
+    {% if filament_sensor_enabled %}
         SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=0
     {% endif %}
 


### PR DESCRIPTION
in case the filament_sensor setting is missing in the material, it is defaulted to 1.
I used this approach to remove a variable and use a single variable to define on start_print if the sensor is enabled or not.