### PR TITLE
Allow homing commands to be over-ridden

### DIFF
--- a/macros/base/homing/homing_override.cfg
+++ b/macros/base/homing/homing_override.cfg
@@ -1,4 +1,26 @@
 # Homing Override for dockable probe
+[gcode_macro _KLIPAIN_HOME_X]
+gcode:
+    G28 X0
+    G1 X{params.X_POSITION_ENDSTOP|float + params.X_HOMING_BACKOFF|float} F{params.HOMING_TRAVEL_SPEED|float}
+
+[gcode_macro _KLIPAIN_HOME_Y]
+gcode:
+    G28 Y0
+    G1 Y{params.Y_POSITION_ENDSTOP|float + params.Y_HOMING_BACKOFF|float} F{params.HOMING_TRAVEL_SPEED|float}
+
+[gcode_macro _KLIPAIN_HOME_Z]
+gcode:
+    G28 Z0
+
+    G91
+    {% if printer["configfile"].settings["stepper_z"]["homing_positive_dir"] == False %}
+        G0 Z{params.HOMING_ZHOP|float} F{params.Z_DROP_SPEED|float} # small Z hop to avoid grinding the bed (as we should be close to Z0 right now)
+    {% elif printer["configfile"].settings["stepper_z"]["homing_positive_dir"] == True %}
+        G0 Z-{params.HOMING_ZHOP|float} F{params.Z_DROP_SPEED|float} # small Z move in the opposite direction to avoid staying on the endstop (not dangerous since we should be at Z max)
+    {% endif %}
+    G90
+
 [homing_override]
 axes: xyz
 gcode:
@@ -142,8 +164,7 @@ gcode:
                     M400
                 {% endif %}
             {% endif %}
-            G28 X0
-            G1 X{x_position_endstop + x_homing_backoff} F{homing_travel_speed}
+	    _KLIPAIN_HOME_X X_POSITION_ENDSTOP={x_position_endstop} X_HOMING_BACKOFF={x_homing_backoff} HOMING_TRAVEL_SPEED={homing_travel_speed}
             {% if sensorless_homing_enabled %}
                 {% if kinematics == "corexy" %}
                     M400
@@ -183,8 +204,7 @@ gcode:
                     M400
                 {% endif %}
             {% endif %}
-            G28 Y0
-            G1 Y{y_position_endstop + y_homing_backoff} F{homing_travel_speed}
+	    _KLIPAIN_HOME_Y Y_POSITION_ENDSTOP={y_position_endstop} Y_HOMING_BACKOFF={y_homing_backoff} HOMING_TRAVEL_SPEED={homing_travel_speed}
             {% if sensorless_homing_enabled %}
                 {% if kinematics == "corexy" %}
                     M400
@@ -224,8 +244,7 @@ gcode:
                     M400
                 {% endif %}
             {% endif %}
-            G28 Y0
-            G1 Y{y_position_endstop + y_homing_backoff} F{homing_travel_speed}
+	    _KLIPAIN_HOME_Y Y_POSITION_ENDSTOP={y_position_endstop} Y_HOMING_BACKOFF={y_homing_backoff} HOMING_TRAVEL_SPEED={homing_travel_speed}
             {% if sensorless_homing_enabled %}
                 {% if kinematics == "corexy" %}
                     M400
@@ -266,8 +285,7 @@ gcode:
                     M400
                 {% endif %}
             {% endif %}
-            G28 X0
-            G1 X{x_position_endstop + x_homing_backoff} F{homing_travel_speed}
+	    _KLIPAIN_HOME_X X_POSITION_ENDSTOP={x_position_endstop} X_HOMING_BACKOFF={x_homing_backoff} HOMING_TRAVEL_SPEED={homing_travel_speed}
             {% if sensorless_homing_enabled %}
                 {% if kinematics == "corexy" %}
                     M400
@@ -317,15 +335,7 @@ gcode:
             _GOTO_Z_PROBE
         {% endif %}
 
-        G28 Z0
-
-        G91
-        {% if printer["configfile"].settings["stepper_z"]["homing_positive_dir"] == False %}
-            G0 Z{homing_zhop} F{z_drop_speed} # small Z hop to avoid grinding the bed (as we should be close to Z0 right now)
-        {% elif printer["configfile"].settings["stepper_z"]["homing_positive_dir"] == True %}
-            G0 Z-{homing_zhop} F{z_drop_speed} # small Z move in the opposite direction to avoid staying on the endstop (not dangerous since we should be at Z max)
-        {% endif %}
-        G90
+        _KLIPAIN_HOME_Z HOMING_ZHOP={homing_zhop} Z_DROP_SPEED={z_drop_speed}
 
         # if voron tap, restore original temperature
         # if dockable probe as virtual endstop, then dock the probe


### PR DESCRIPTION
Currently, the only way to customize the homing logic is to define a `[homing_override]` override, which is overkill for some applications. This creates `_KLIPAIN_HOME_XXX` macros that are called in the existing `homing_override` and can be overridden to customize homing behavior in a more targeted way.

I made these changes in because I use sensorless homing on one axis only, and I wanted to create a custom macro similar to https://klipper.discourse.group/t/sensorless-homing-macro-suggested-in-klipper-docs/896 that allows me to home twice with a pause between for StallGuard to reset.