### PR TITLE
 BTT_SB2209_RP2040: Add missing  MCU_ONBOARD_NTC100K def

### DIFF
--- a/config/mcu_definitions/toolhead/BTT_SB2209_RP2040_v1.0.cfg
+++ b/config/mcu_definitions/toolhead/BTT_SB2209_RP2040_v1.0.cfg
@@ -10,6 +10,8 @@ aliases:
     MCU_HE0=gpio7  ,
     MCU_TH0=gpio27 ,
 
+    MCU_ONBOARD_NTCK100K=gpio28 ,
+
     MCU_IND_FAN=gpio6     ,
     MCU_FAN1_PWM=gpio14   , MCU_FAN2_PWM=gpio13  ,
     MCU_4WFAN_TACH=gpio12 , MCU_4WFAN_PWM=gpio15 ,


### PR DESCRIPTION
The MCU template define the alias`CHAMBER_TEMPERATURE=MCU_ONBOARD_NTCK100K` but `MCU_ONBOARD_NTCK100K` is not defined in `mcu_definitions/toolhead/BTT_SB2209_RP2040_v1.0.cfg`.