### PR TITLE
Add 2 TMC motor/stepper Z axis support

### DIFF
--- a/config/hardware/axis/Z/TMC/TMC2209_2-Motors.cfg
+++ b/config/hardware/axis/Z/TMC/TMC2209_2-Motors.cfg
@@ -1,0 +1,8 @@
+[include TMC2209_1-Motor.cfg]
+
+[tmc2209 stepper_z1]
+uart_pin: Z1_TMCUART
+interpolate: True
+run_current: 0.8
+sense_resistor: 0.110
+stealthchop_threshold: 0

--- a/config/hardware/axis/Z/TMC/TMC2240_2-Motors.cfg
+++ b/config/hardware/axis/Z/TMC/TMC2240_2-Motors.cfg
@@ -1,0 +1,11 @@
+[include TMC2240_1-Motor.cfg]
+
+[tmc2240 stepper_z1]
+cs_pin: Z1_TMCUART
+spi_speed: 500000
+spi_software_sclk_pin: DRIVER_SPI_SCK
+spi_software_mosi_pin: DRIVER_SPI_MOSI
+spi_software_miso_pin: DRIVER_SPI_MISO
+interpolate: True
+run_current: 0.7
+stealthchop_threshold: 0

--- a/config/hardware/axis/Z/TMC/TMC5160_2-Motors.cfg
+++ b/config/hardware/axis/Z/TMC/TMC5160_2-Motors.cfg
@@ -1,0 +1,12 @@
+[include TMC5160_1-Motor.cfg]
+
+[tmc5160 stepper_z1]
+cs_pin: Z1_TMCUART
+spi_speed: 500000
+spi_software_sclk_pin: DRIVER_SPI_SCK
+spi_software_mosi_pin: DRIVER_SPI_MOSI
+spi_software_miso_pin: DRIVER_SPI_MISO
+interpolate: True
+run_current: 0.8
+sense_resistor: 0.075
+stealthchop_threshold: 0


### PR DESCRIPTION
This comes in handy for dual lead screw systems, which are wired to seperate drivers.
Also this aids to make use of z_tilt with 2 Z axis TMC steppers