### PR TITLE
feature(tap) Added chaoticlab CNC tap settings.

### DIFF
--- a/config/hardware/probes/chaoticlab-cnc-tap-v2.cfg
+++ b/config/hardware/probes/chaoticlab-cnc-tap-v2.cfg
@@ -1,0 +1,12 @@
+# Chaotic Lab CNC Tap is a little less sensitive, and needs it's own settings.
+# It is based on the default voron_tap config
+# @see (https://github.com/Chaoticlab/CNC-Tap-for-Voron/blob/master/Manual/CNC%20Tap%20V2.cfg)
+[include voron_tap.cfg]
+
+[probe]
+speed: 5.0
+samples: 2
+samples_result: median
+sample_retract_dist: 3.0
+samples_tolerance: 0.05
+samples_tolerance_retries: 3

--- a/config/hardware/probes/chaoticlab-cnc-tap-v2.cfg
+++ b/config/hardware/probes/chaoticlab-cnc-tap-v2.cfg
@@ -1,0 +1,12 @@
+# Chaotic Lab CNC Tap is a little less sensitive, and needs it's own settings.
+# It is based on the default voron_tap config
+# @see (https://github.com/Chaoticlab/CNC-Tap-for-Voron/blob/master/Manual/CNC%20Tap%20V2.cfg)
+[include config/hardware/probes/voron_tap.cfg]
+
+[probe]
+speed: 5.0
+samples: 2
+samples_result: median
+sample_retract_dist: 3.0
+samples_tolerance: 0.05
+samples_tolerance_retries: 3


### PR DESCRIPTION
Adding the choatic lab cnc probe, which has a higher threshold as it is more prone to failure on gantry checking and height maps.

It used the base voron_tap, so all the macros and pin settings remain.