### PR TITLE
Prime line wipe

### DIFF
--- a/macros/helpers/prime_line.cfg
+++ b/macros/helpers/prime_line.cfg
@@ -119,12 +119,12 @@ gcode:
     {% if prime_line_direction == "X" %}
         G1 X{prime_line_x + prime_line_way*prime_line_length} E{prime_line_purge_distance} F{speed}
         {% if prime_line_wipe %}
-            G0 X{prime_line_x + prime_line_wipe_length} F{St}
+            G0 X{prime_line_x + prime_line_way*prime_line_wipe_length} F{St}
         {% endif %}
     {% elif prime_line_direction == "Y" %}
         G1 Y{prime_line_y + prime_line_way*prime_line_length} E{prime_line_purge_distance} F{speed}
         {% if prime_line_wipe %}
-            G0 Y{prime_line_y + prime_line_wipe_length} F{St}
+            G0 Y{prime_line_y + prime_line_way*prime_line_wipe_length} F{St}
         {% endif %}        
     {% else %}
         { action_respond_error("Prime line direction is not valid. Choose either X or Y in the variables.cfg file!") }

--- a/macros/helpers/prime_line.cfg
+++ b/macros/helpers/prime_line.cfg
@@ -7,7 +7,8 @@ gcode:
     {% set prime_line_height = params.LINE_HEIGHT|default(printer["gcode_macro _USER_VARIABLES"].prime_line_height)|default(0.6)|float %}
     {% set prime_line_adaptive = params.ADAPTIVE_MODE|default(1)|int %}
     {% set prime_line_margin = params.LINE_MARGIN|default(printer["gcode_macro _USER_VARIABLES"].prime_line_margin)|default(5.0)|float %} # Used only in adaptive mode
-    
+    {% set prime_line_wipe_length = prime_line_length * 0.8 %}
+
     # If the SIZE parameter is defined and not a dummy placeholder, we use it to do the adaptive bed mesh logic
     {% set coordinatesFound = false %}
     {% if params.SIZE is defined and params.SIZE != "0_0_0_0" %}
@@ -52,6 +53,8 @@ gcode:
     {% set St = printer["gcode_macro _USER_VARIABLES"].travel_speed * 60 %}
     {% set Sz = printer["gcode_macro _USER_VARIABLES"].z_drop_speed * 60 %}
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
+
+    {% set wipe = printer["gcode_macro _USER_VARIABLES"].prime_line_wipe %}
 
     {% set klippain_mmu_enabled = printer["gcode_macro _USER_VARIABLES"].klippain_mmu_enabled %}
     {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
@@ -116,8 +119,14 @@ gcode:
     G92 E0
     {% if prime_line_direction == "X" %}
         G1 X{prime_line_x + prime_line_way*prime_line_length} E{prime_line_purge_distance} F{speed}
+        {% if wipe %}
+            G1 X{prime_line_x + prime_line_wipe_length} F{St}
+        {% endif %}
     {% elif prime_line_direction == "Y" %}
         G1 Y{prime_line_y + prime_line_way*prime_line_length} E{prime_line_purge_distance} F{speed}
+        {% if wipe %}
+            G1 Y{prime_line_y + prime_line_wipe_length} F{St}
+        {% endif %}        
     {% else %}
         { action_respond_error("Prime line direction is not valid. Choose either X or Y in the variables.cfg file!") }
     {% endif %}

--- a/macros/helpers/prime_line.cfg
+++ b/macros/helpers/prime_line.cfg
@@ -119,12 +119,12 @@ gcode:
     {% if prime_line_direction == "X" %}
         G1 X{prime_line_x + prime_line_way*prime_line_length} E{prime_line_purge_distance} F{speed}
         {% if prime_line_wipe %}
-            G1 X{prime_line_x + prime_line_wipe_length} F{St}
+            G0 X{prime_line_x + prime_line_wipe_length} F{St}
         {% endif %}
     {% elif prime_line_direction == "Y" %}
         G1 Y{prime_line_y + prime_line_way*prime_line_length} E{prime_line_purge_distance} F{speed}
         {% if prime_line_wipe %}
-            G1 Y{prime_line_y + prime_line_wipe_length} F{St}
+            G0 Y{prime_line_y + prime_line_wipe_length} F{St}
         {% endif %}        
     {% else %}
         { action_respond_error("Prime line direction is not valid. Choose either X or Y in the variables.cfg file!") }

--- a/macros/helpers/prime_line.cfg
+++ b/macros/helpers/prime_line.cfg
@@ -7,6 +7,7 @@ gcode:
     {% set prime_line_height = params.LINE_HEIGHT|default(printer["gcode_macro _USER_VARIABLES"].prime_line_height)|default(0.6)|float %}
     {% set prime_line_adaptive = params.ADAPTIVE_MODE|default(1)|int %}
     {% set prime_line_margin = params.LINE_MARGIN|default(printer["gcode_macro _USER_VARIABLES"].prime_line_margin)|default(5.0)|float %} # Used only in adaptive mode
+    {% set prime_line_wipe = printer["gcode_macro _USER_VARIABLES"].prime_line_wipe|default(False) %}
     {% set prime_line_wipe_length = prime_line_length * 0.8 %}
 
     # If the SIZE parameter is defined and not a dummy placeholder, we use it to do the adaptive bed mesh logic
@@ -53,8 +54,6 @@ gcode:
     {% set St = printer["gcode_macro _USER_VARIABLES"].travel_speed * 60 %}
     {% set Sz = printer["gcode_macro _USER_VARIABLES"].z_drop_speed * 60 %}
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
-
-    {% set wipe = printer["gcode_macro _USER_VARIABLES"].prime_line_wipe %}
 
     {% set klippain_mmu_enabled = printer["gcode_macro _USER_VARIABLES"].klippain_mmu_enabled %}
     {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
@@ -119,12 +118,12 @@ gcode:
     G92 E0
     {% if prime_line_direction == "X" %}
         G1 X{prime_line_x + prime_line_way*prime_line_length} E{prime_line_purge_distance} F{speed}
-        {% if wipe %}
+        {% if prime_line_wipe %}
             G1 X{prime_line_x + prime_line_wipe_length} F{St}
         {% endif %}
     {% elif prime_line_direction == "Y" %}
         G1 Y{prime_line_y + prime_line_way*prime_line_length} E{prime_line_purge_distance} F{speed}
-        {% if wipe %}
+        {% if prime_line_wipe %}
             G1 Y{prime_line_y + prime_line_wipe_length} F{St}
         {% endif %}        
     {% else %}

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -59,6 +59,7 @@ variable_prime_line_purge_distance: 30 # length of filament to purge (in mm)
 variable_prime_line_flowrate: 10 # mm3/s used for the prime line
 variable_prime_line_height: 0.6 # mm, used for actual cross section computation
 variable_prime_line_margin: 5  # distance of purge line from fl_size rectangle
+variable_prime_line_wipe: True # enable a wipe of the nozzle after completing the prime line
 
 ## Park position used when pause, end_print, etc...
 variable_park_position_xy: -1, -1

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -59,7 +59,7 @@ variable_prime_line_purge_distance: 30 # length of filament to purge (in mm)
 variable_prime_line_flowrate: 10 # mm3/s used for the prime line
 variable_prime_line_height: 0.6 # mm, used for actual cross section computation
 variable_prime_line_margin: 5  # distance of purge line from fl_size rectangle
-variable_prime_line_wipe: True # enable a wipe of the nozzle after completing the prime line
+variable_prime_line_wipe: False # enable a wipe of the nozzle after completing the prime line
 
 ## Park position used when pause, end_print, etc...
 variable_park_position_xy: -1, -1


### PR DESCRIPTION
Add logic to allow a user to enable a nozzle wipe after laying down a prime line immediately before the print starts.