### PR TITLE
Mini12864 beeper change due to klipper change

### DIFF
--- a/config/hardware/displays/BTT_mini12864.cfg
+++ b/config/hardware/displays/BTT_mini12864.cfg
@@ -27,7 +27,7 @@ spi_software_miso_pin: EXP2_1
 spi_software_mosi_pin: EXP2_6
 spi_software_sclk_pin: EXP2_2
 
-[output_pin beeper]
+[pwm_cycle_time beeper]
 pin: EXP1_1
 
 [neopixel btt_mini12864]

--- a/config/hardware/displays/BTT_mini12864_inversed.cfg
+++ b/config/hardware/displays/BTT_mini12864_inversed.cfg
@@ -27,7 +27,7 @@ spi_software_miso_pin: EXP2_10
 spi_software_mosi_pin: EXP2_5
 spi_software_sclk_pin: EXP2_9
 
-[output_pin beeper]
+[pwm_cycle_time beeper]
 pin: EXP1_10
 
 [neopixel btt_mini12864]

--- a/config/hardware/displays/Fysetc_mini12864.cfg
+++ b/config/hardware/displays/Fysetc_mini12864.cfg
@@ -27,7 +27,7 @@ spi_software_miso_pin: EXP2_10
 spi_software_mosi_pin: EXP2_5
 spi_software_sclk_pin: EXP2_9
 
-[output_pin beeper]
+[pwm_cycle_time beeper]
 pin: EXP1_10
 
 [neopixel fysetc_mini12864]

--- a/config/hardware/displays/Fysetc_mini12864_inversed.cfg
+++ b/config/hardware/displays/Fysetc_mini12864_inversed.cfg
@@ -27,7 +27,7 @@ spi_software_miso_pin: EXP2_1
 spi_software_mosi_pin: EXP2_6
 spi_software_sclk_pin: EXP2_2
 
-[output_pin beeper]
+[pwm_cycle_time beeper]
 pin: EXP1_1
 
 [neopixel fysetc_mini12864]

--- a/config/hardware/displays/Fysetc_mini12864_v1.2_v2.0.cfg
+++ b/config/hardware/displays/Fysetc_mini12864_v1.2_v2.0.cfg
@@ -24,7 +24,7 @@ spi_software_miso_pin: EXP2_10
 spi_software_mosi_pin: EXP2_5
 spi_software_sclk_pin: EXP2_9
 
-[output_pin beeper]
+[pwm_cycle_time beeper]
 pin: EXP1_10
 
 [led fysetc_mini12864]

--- a/config/hardware/displays/Fysetc_mini12864_v1.2_v2.0_inversed.cfg
+++ b/config/hardware/displays/Fysetc_mini12864_v1.2_v2.0_inversed.cfg
@@ -24,7 +24,7 @@ spi_software_miso_pin: EXP2_1
 spi_software_mosi_pin: EXP2_6
 spi_software_sclk_pin: EXP2_2
 
-[output_pin beeper]
+[pwm_cycle_time beeper]
 pin: EXP1_1
 
 [led fysetc_mini12864]


### PR DESCRIPTION
Klipper Configuration Changes: "20240123: The output_pin SET_PIN CYCLE_TIME parameter has been removed. Use the new pwm_cycle_time module if it is necessary to dynamically change a pwm pin's cycle time."