### PR TITLE
Add a variable distance for end_print extruder pull back.

### DIFF
--- a/macros/base/end_print.cfg
+++ b/macros/base/end_print.cfg
@@ -25,7 +25,7 @@ gcode:
     {% elif printer.extruder.can_extrude %}
         # pull back the filament a little bit
         G92 E0
-        G1 E-10 F2100
+        G1 E{extruder_pull_back_distance_end_print} F2100
     {% endif %}
 
     {% if turn_off_heaters_in_end_print %}

--- a/macros/base/end_print.cfg
+++ b/macros/base/end_print.cfg
@@ -25,7 +25,7 @@ gcode:
     {% elif printer.extruder.can_extrude %}
         # pull back the filament a little bit
         G92 E0
-        G1 E{extruder_pull_back_distance_end_print} F2100
+        G1 E-10 F2100
     {% endif %}
 
     {% if turn_off_heaters_in_end_print %}

--- a/macros/base/end_print.cfg
+++ b/macros/base/end_print.cfg
@@ -14,7 +14,8 @@ gcode:
     {% set filter_default_time = printer["gcode_macro _USER_VARIABLES"].filter_default_time_on_end_print|default(600)|int %}
     {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
     {% set hotend_fan_tach_enabled = printer["gcode_macro _USER_VARIABLES"].hotend_fan_tach_enabled %}
-
+    {% set extruder_pull_back_distance_end_print = printer["gcode_macro _USER_VARIABLES"].extruder_pull_back_distance_end_print %}
+    
     PARK
 
     {% if klippain_mmu_enabled %}
@@ -25,7 +26,7 @@ gcode:
     {% elif printer.extruder.can_extrude %}
         # pull back the filament a little bit
         G92 E0
-        G1 E-10 F2100
+        G1 E{extruder_pull_back_distance_end_print} F2100
     {% endif %}
 
     {% if turn_off_heaters_in_end_print %}

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -64,6 +64,9 @@ variable_prime_line_margin: 5  # distance of purge line from fl_size rectangle
 variable_park_position_xy: -1, -1
 variable_park_lift_z: 50
 
+## Extruder parameter in the END_PRINT macro
+variable_extruder_pull_back_distance_end_print: -10 # should be negative for a pull
+
 ## Automatically disable motors in the END_PRINT macro
 variable_disable_motors_in_end_print: False
 

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -64,9 +64,6 @@ variable_prime_line_margin: 5  # distance of purge line from fl_size rectangle
 variable_park_position_xy: -1, -1
 variable_park_lift_z: 50
 
-## Extruder parameter in the END_PRINT macro
-variable_extruder_pull_back_distance_end_print: -10 # should be negative for a pull
-
 ## Automatically disable motors in the END_PRINT macro
 variable_disable_motors_in_end_print: False
 


### PR DESCRIPTION
I like to have the end_print pull back distance a variable.
Why: I have different toolheads with different hot zone lengths and I like the filament pulled in the cold zone according to the toolhead.