### PR TITLE
Update homing_override.cfg with a M400 to ensure the nozzle is lifted

### DIFF
--- a/macros/base/homing/homing_override.cfg
+++ b/macros/base/homing/homing_override.cfg
@@ -89,6 +89,7 @@ gcode:
                 {% endif %}
                 G91
                 G0 Z{homing_zhop} F{z_drop_speed}
+                M400
                 G90
             {% else %}
                 {% if verbose %}


### PR DESCRIPTION
Add a M400 command after the z hop gcode to ensure the nozzle is lifted before anything else is allowed to happen to prevent nozzle crashes. This happend while testing out my new Cartographer3D eddy current bed probe where somehow the cartographer klipper plugin executed a move to the homing position before the nozzle was lifted from the bed surface an scratched it.