### PR TITLE
Add a variable distance for prime_line nozzle pressure push.

### DIFF
--- a/macros/helpers/prime_line.cfg
+++ b/macros/helpers/prime_line.cfg
@@ -7,6 +7,7 @@ gcode:
     {% set prime_line_height = params.LINE_HEIGHT|default(printer["gcode_macro _USER_VARIABLES"].prime_line_height)|default(0.6)|float %}
     {% set prime_line_adaptive = params.ADAPTIVE_MODE|default(1)|int %}
     {% set prime_line_margin = params.LINE_MARGIN|default(printer["gcode_macro _USER_VARIABLES"].prime_line_margin)|default(5.0)|float %} # Used only in adaptive mode
+    {% set prime_line_nozzle_pressure_push = printer["gcode_macro _USER_VARIABLES"].prime_line_nozzle_pressure_push|float %}
     
     # If the SIZE parameter is defined and not a dummy placeholder, we use it to do the adaptive bed mesh logic
     {% set coordinatesFound = false %}
@@ -110,7 +111,7 @@ gcode:
 
     # Add pressure in the nozzle
     G92 E0
-    G1 E18 F300
+    G1 E{prime_line_nozzle_pressure_push} F300
 
     # Prime line
     G92 E0

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -59,6 +59,7 @@ variable_prime_line_purge_distance: 30 # length of filament to purge (in mm)
 variable_prime_line_flowrate: 10 # mm3/s used for the prime line
 variable_prime_line_height: 0.6 # mm, used for actual cross section computation
 variable_prime_line_margin: 5  # distance of purge line from fl_size rectangle
+variable_prime_line_nozzle_pressure_push: 18 # extruder distance to set nozzle pressure before the prime line
 
 ## Park position used when pause, end_print, etc...
 variable_park_position_xy: -1, -1


### PR DESCRIPTION
We don't know for sure how far the filament is in toolhead before prime_line. For the moment the prime_line push is hard coded to 18. I propose to set it as a variable then one want to adjust it.
Request from @wight554 here: https://github.com/Frix-x/klippain/issues/593