### PR TITLE
feat: Set idle timeout on pause

### DIFF
--- a/macros/base/pause_resume.cfg
+++ b/macros/base/pause_resume.cfg
@@ -4,6 +4,7 @@ description: Pause the print and park
 gcode:
     {% set light_enabled = printer["gcode_macro _USER_VARIABLES"].light_enabled %}
     {% set light_intensity_start_print = printer["gcode_macro _USER_VARIABLES"].light_intensity_start_print %}
+    {% set idle_timeout_on_pause = printer["gcode_macro _USER_VARIABLES"].idle_timeout_on_pause|default(0)|int %}
 
     {% if printer.pause_resume.is_paused %}
         RESPOND MSG="Print is already paused"
@@ -12,8 +13,13 @@ gcode:
         {% if light_enabled %}
             LIGHT_ON S={light_intensity_start_print}
         {% endif %}
+
         BASE_PAUSE
         PARK
+
+        {% if idle_timeout_on_pause > 0 %}
+            SET_IDLE_TIMEOUT TIMEOUT={idle_timeout_on_pause}
+        {% endif %}
     {% endif %}
 
 
@@ -25,6 +31,7 @@ gcode:
     {% set light_enabled = printer["gcode_macro _USER_VARIABLES"].light_enabled %}
     {% set light_intensity_printing = printer["gcode_macro _USER_VARIABLES"].light_intensity_printing %}
     {% set klippain_mmu_enabled = printer["gcode_macro _USER_VARIABLES"].klippain_mmu_enabled %}
+    {% set idle_timeout_on_pause = printer["gcode_macro _USER_VARIABLES"].idle_timeout_on_pause|default(0)|int %}
 
     {% if not printer.pause_resume.is_paused %}
         RESPOND MSG="Print is not paused. Resume ignored"
@@ -38,8 +45,14 @@ gcode:
         {% else %}
             RESTORE_GCODE_STATE NAME=PAUSE_state MOVE=1 MOVE_SPEED={St}
         {% endif %}
+
         {% if light_enabled %}
             LIGHT_ON S={light_intensity_printing}
         {% endif %}
+
+        {% if idle_timeout_on_pause > 0%}
+            SET_IDLE_TIMEOUT TIMEOUT={printer.configfile.settings.idle_timeout.timeout}
+        {% endif %}
+
         BASE_RESUME
     {% endif %}

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -21,9 +21,9 @@ variable_brush_clean_accel: 1500
 variable_probe_dock_accel: 2000
 
 
-#################################################
-# Homing, start_print and end_print variables
-#################################################
+#####################################################
+# Homing, start_print, end_print and pause variables
+#####################################################
 
 ## Physical Z endstop pin position. This variable is used only if
 ## you don't use the automatic z_calibration plugin: if this plugin is
@@ -69,6 +69,9 @@ variable_disable_motors_in_end_print: False
 
 ## Automatically turn-off heaters in the END_PRINT macro
 variable_turn_off_heaters_in_end_print: True
+
+## Set idle timeout duration when a print job is paused. 0 means no change
+variable_idle_timeout_on_pause: 0
 
 
 #########################################################


### PR DESCRIPTION
Extending idle timeouts helps save prints during filament run-outs by keeping the heated bed on.