### PR TITLE
feat: Reset velocity limits in END_PRINT macro

### DIFF
--- a/macros/base/end_print.cfg
+++ b/macros/base/end_print.cfg
@@ -2,7 +2,7 @@
 ## Available actions: "retract_filament", "turn_off_heaters", "turn_off_fans", "turn_off_motors"
 ##
 [gcode_macro _USER_VARIABLES]
-variable_endprint_actions: "retract_filament", "turn_off_heaters", "turn_off_fans", "turn_off_motors"
+variable_endprint_actions: "retract_filament", "turn_off_heaters", "turn_off_fans", "turn_off_motors", "reset_limits"
 gcode: # do not remove this line
 
 [gcode_macro END_PRINT]
@@ -44,6 +44,8 @@ gcode:
             _MODULE_TURN_OFF_FANS
         {% elif action == "turn_off_motors" %}
             _MODULE_TURN_OFF_MOTORS
+        {% elif action == "reset_limits" %}
+            _MODULE_RESET_LIMITS
         {% else %}
             {% if "_END_PRINT_ACTION_%s" % (action|upper) in printer.gcode.commands %}
                 _END_PRINT_ACTION_{action|upper} {rawparams}
@@ -135,4 +137,37 @@ gcode:
 
     {% if disable_motors_in_end_print %}
         M84
+    {% endif %}
+
+
+[gcode_macro _MODULE_RESET_LIMITS]
+gcode:
+    # ----- RESET LIMITS ---------------------------------
+    # Reset velocity limits, extrusion and speed factor (if configured)
+    {% set reset_velocity_limits = printer["gcode_macro _USER_VARIABLES"].reset_velocity_limits_in_end_print %}
+    {% set reset_extrude_factor = printer["gcode_macro _USER_VARIABLES"].reset_extrude_factor_in_end_print %}
+    {% set reset_speed_factor = printer["gcode_macro _USER_VARIABLES"].reset_speed_factor_in_end_print %}
+
+    {% if reset_speed_factor %}
+        M220 S100
+    {% endif %}
+
+    {% if reset_extrude_factor %}
+        M221 S100
+    {% endif %}
+
+    {% if reset_velocity_limits %}
+        SET_VELOCITY_LIMIT VELOCITY={printer.configfile.settings.printer.max_velocity}
+        SET_VELOCITY_LIMIT ACCEL={printer.configfile.settings.printer.max_accel}
+        SET_VELOCITY_LIMIT SQUARE_CORNER_VELOCITY={printer.configfile.settings.printer.square_corner_velocity}
+
+        # Legacy Klipper versions
+        {% if printer.configfile.settings.printer.max_accel_to_decel is defined %}
+            SET_VELOCITY_LIMIT ACCEL_TO_DECEL={printer.configfile.settings.printer.max_accel_to_decel}
+        {% endif %}
+
+        # Modern Klipper versions
+        {% if printer.configfile.settings.printer.minimum_cruise_ratio is defined %}
+            SET_VELOCITY_LIMIT MINIMUM_CRUISE_RATIO={printer.configfile.settings.printer.minimum_cruise_ratio}
+        {% endif %}
     {% endif %}

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -70,6 +70,15 @@ variable_disable_motors_in_end_print: False
 ## Automatically turn-off heaters in the END_PRINT macro
 variable_turn_off_heaters_in_end_print: True
 
+## Automatically reset velocity limits to configured values in the END_PRINT macro
+variable_reset_velocity_limits_in_end_print: True
+
+## Automatically reset extrude factor to 100% in the END_PRINT macro
+variable_reset_extrude_factor_in_end_print: True
+
+## Automatically reset speed factor to 100% in the END_PRINT macro
+variable_reset_speed_factor_in_end_print: True
+
 
 #########################################################
 # Dockable probe variables (if available in the machine)


### PR DESCRIPTION
Reset the velocity limits to the values from the config in the END_PRINT macro.
