### PR TITLE
refactor: swap MMU_EJECT to MMU_UNLOAD

### DIFF
--- a/docs/mmu.md
+++ b/docs/mmu.md
@@ -65,7 +65,7 @@ If you want to print without using the MMU features, you can use the MMU bypass 
   1. Select the bypass mode with `MMU_SELECT_BYPASS`.
   1. Finally, manually insert the filament into the bowden tube up to the extruder gears and load the filament with the `MMU_LOAD` command or start the print (the `START_PRINT` sequence will automatically try to load the filament into the toolhead).
 
-At the end of the print, you can use the `MMU_EJECT` command (if `variable_mmu_unload_on_end_print` is set to False in Klippain `variables.cfg`, otherwise it is ejected automatically) to unload the filament from the extruder and then manually pull it out of the bowden tube.
+At the end of the print, you can use the `MMU_UNLOAD` command (if `variable_mmu_unload_on_end_print` is set to False in Klippain `variables.cfg`, otherwise it is unloaded automatically) to unload the filament from the extruder and then manually pull it out of the bowden tube.
 
 ### Spoolman support with MMU
 

--- a/macros/base/cancel_print.cfg
+++ b/macros/base/cancel_print.cfg
@@ -20,7 +20,7 @@ gcode:
     {% if klippain_mmu_enabled and mmu_unload_on_cancel_print %}
         {% if printer.mmu.enabled and printer.mmu.tool|int != -2 %}
             # Unload filament and park the MMU
-            MMU_EJECT
+            MMU_UNLOAD
         {% endif %}
     {% elif printer.extruder.can_extrude %}
         # Pull back the filament a little bit

--- a/macros/base/end_print.cfg
+++ b/macros/base/end_print.cfg
@@ -20,7 +20,7 @@ gcode:
     {% if klippain_mmu_enabled %}
         {% if printer.mmu.enabled and mmu_unload %}
             # unload filament and park into MMU. Or just unload filament out of extruder if using bypass.
-            MMU_EJECT
+            MMU_UNLOAD
         {% endif %}
     {% elif printer.extruder.can_extrude %}
         # pull back the filament a little bit

--- a/macros/hardware_functions/mmu.cfg
+++ b/macros/hardware_functions/mmu.cfg
@@ -38,8 +38,8 @@ gcode:
                             RESPOND PREFIX='MMU info:' MSG="<span class="success"--text> You are planning a multi-filament print. The tool(s): {TOOLS_USED} will be checked to limit the risk of errors.</span>"
                         {% endif %}
 
-                        # First eject in case a bad tool is already loaded, then check the gates and select the initial tool
-                        MMU_EJECT
+                        # First unload in case a bad tool is already loaded, then check the gates and select the initial tool
+                        MMU_UNLOAD
                         MMU_CHECK_GATE TOOLS={TOOLS_USED}
                         MMU_SELECT TOOL={INITIAL_TOOL}
 
@@ -53,8 +53,8 @@ gcode:
                             {% endif %}
                         {% endif %}
 
-                        # First eject in case a bad tool is already loaded, then check the initial tool gate
-                        MMU_EJECT
+                        # First unload in case a bad tool is already loaded, then check the initial tool gate
+                        MMU_UNLOAD
                         MMU_CHECK_GATE TOOLS={INITIAL_TOOL}
                     {% endif %}
                 
@@ -118,7 +118,7 @@ gcode:
                 {% endif %}
             {% else %}
                 {% if printer.mmu.tool|int != INITIAL_TOOL %}
-                    MMU_EJECT
+                    MMU_UNLOAD
                     MMU_SELECT TOOL={INITIAL_TOOL}
                     MMU_PRELOAD
                 {% endif %}


### PR DESCRIPTION
In the upcoming Happy Hare v3, eject behaves slightly different for "Type B" MMU's, where it ejects the spool out of the MMU where unload just retracts and parks it.

In Happy Hare v2, `MMU_EJECT` and `MMU_UNLOAD` ran the same code, so they are interchangeable in v2.