### PR TITLE
Update end_print.cfg

### DIFF
--- a/macros/base/end_print.cfg
+++ b/macros/base/end_print.cfg
@@ -45,10 +45,6 @@ gcode:
         BED_MESH_CLEAR
     {% endif %}
 
-    {% if disable_motors_in_end_print %}
-        M84
-    {% endif %}
-
 
     # If a filter is connected, and used during the print, continue filtering the air
     # for a couple of min before stopping everything
@@ -77,3 +73,13 @@ gcode:
     {% if filament_sensor_enabled %}
         SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=1
     {% endif %}
+
+    #Set the HE to 50°C and wait. The HE is already cooling. 
+    M109 S50
+
+    {% if disable_motors_in_end_print %}
+        M84
+    {% endif %}
+
+    #kill HE
+    TURN_OFF_HEATERS


### PR DESCRIPTION
Move Motor OFF at the end of the script due to gantry drop with a hot HE. This is a problem with a full plate