### PR TITLE
Add Cartographer3D V3 with Touch configuration

### DIFF
--- a/config/hardware/accelerometers/cartographer_v3_accelerometer.cfg
+++ b/config/hardware/accelerometers/cartographer_v3_accelerometer.cfg
@@ -1,0 +1,6 @@
+[include generics/adxl345_hardware_spi1.cfg]
+
+# You need to include the section for the cartographer in your printer.cfg and include cartographer_virtual.cfg
+# and set the correct serial for this to work.
+[adxl345]
+cs_pin: scanner:PA3

--- a/config/hardware/probes/cartographer_v3_virtual.cfg
+++ b/config/hardware/probes/cartographer_v3_virtual.cfg
@@ -1,0 +1,48 @@
+# This probe type is for a cartographer probe used directly as a virtual Z endstop
+# rather than with an existing physical endstop. To use this configuration,
+# you will need to manually add the cartographer Klipper plugin!
+
+[gcode_macro _USER_VARIABLES]
+variable_probe_type_enabled: "cartographer_touch"
+variable_startprint_actions: "bed_soak", "extruder_preheating", "chamber_soak", "tilt_calib", "z_offset", "bedmesh", "clean", "cartographer_touch", "extruder_heating", "purge", "clean", "primeline"
+variable_homing_zhop: 10
+gcode:
+
+# Cartographer 3D probe definition also include the probe management macro directly from here
+[include ../../../macros/base/probing/generic_probe.cfg]
+
+[scanner]
+mcu: scanner
+#   Offsets are measured from the centre of your coil, to the tip of your nozzle
+#   on a level axis. It is vital that this is accurate.
+x_offset: 0
+#    adjust for your cartographers offset from nozzle to middle of coil
+y_offset: 15
+#    adjust for your cartographers offset from nozzle to middle of coil
+backlash_comp: 0.5
+#   Backlash compensation distance for removing Z backlash before measuring
+#   the sensor response.
+sensor: cartographer
+#    this must be set as cartographer unless using IDM etc.
+sensor_alt: carto
+#    alternate name to call commands. CARTO_TOUCH etc
+mesh_runs: 2
+#    Number of passes to make during mesh scan.
+
+[bed_mesh]
+speed: 200
+#    movement speed of toolhead during bed mesh
+horizontal_move_z: 5
+#    height of scanner during bed mesh scan
+probe_count: 30, 30
+algorithm: bicubic
+
+[temperature_sensor Cartographer_MCU]
+sensor_type: temperature_mcu
+sensor_mcu: scanner
+min_temp: 0
+max_temp: 105
+
+[stepper_z]
+endstop_pin: probe:z_virtual_endstop
+homing_retract_dist: 0

--- a/macros/base/probing/generic_probe.cfg
+++ b/macros/base/probing/generic_probe.cfg
@@ -11,7 +11,6 @@ gcode:
     {% set LOCK = params.LOCK|default(False, boolean=true) %}
 
     {% set probe_type_enabled = printer["gcode_macro _USER_VARIABLES"].probe_type_enabled %}
-    {% set tap_max_probing_temp = printer["gcode_macro _USER_VARIABLES"].tap_max_probing_temp|float %}
 
     # If a dockable probe is defined, then check and ATTACH the probe
     {% if probe_type_enabled == "dockable" or probe_type_enabled == "dockable_virtual" %}
@@ -23,24 +22,27 @@ gcode:
         {% endif %}
 
     # If a Voron TAP probe is defined, then check the temperature and lower it if needed
-    {% elif probe_type_enabled == "vorontap" %}
+    {% elif probe_type_enabled == "vorontap" or probe_type_enabled == "cartographer_touch" %}
         SAVE_GCODE_STATE NAME=BEFORE_TAP_ACTION
 
         {% set ACTUAL_TEMP = printer.extruder.temperature %}
         {% set TARGET_TEMP = printer.extruder.target %}
+        {% set max_probing_temp_variable = "tap_max_probing_temp" if probe_type_enabled == "vorontap" else "cartographer_touch_max_probing_temp" %}
+        {% set max_probing_temp = printer["gcode_macro _USER_VARIABLES"][max_probing_temp_variable]|float %}
+        {% set PROBE_NAME = "TAP" if probe_type_enabled == "vorontap" else "Cartographer Touch" %}
 
         SET_GCODE_VARIABLE MACRO=ACTIVATE_PROBE VARIABLE=temperature VALUE={TARGET_TEMP}
 
-        {% if TARGET_TEMP > tap_max_probing_temp %}
-            { action_respond_info('Extruder temperature target of %.1fC is too high for TAP probing, lowering to %.1fC' % (TARGET_TEMP, tap_max_probing_temp)) }
+        {% if TARGET_TEMP > max_probing_temp %}
+            { action_respond_info('Extruder temperature target of %.1fC is too high for %s probing, lowering to %.1fC' % (TARGET_TEMP, PROBE_NAME, max_probing_temp)) }
             M106 S255 ; 100% the part cooling fan to help the extruder cooling
-            M109 S{tap_max_probing_temp}
+            M109 S{max_probing_temp}
             M106 S0   ; Stop the part cooling fan
         {% else %}
             # Temperature target is already low enough, but nozzle may still be too hot
-            {% if ACTUAL_TEMP > tap_max_probing_temp + 3 %}
+            {% if ACTUAL_TEMP > max_probing_temp + 3 %}
                 M106 S255 ; 100% the part cooling fan to help the extruder cooling
-                TEMPERATURE_WAIT SENSOR=extruder MAXIMUM={tap_max_probing_temp}
+                TEMPERATURE_WAIT SENSOR=extruder MAXIMUM={max_probing_temp}
                 M106 S0   ; Stop the part cooling fan
             {% endif %}
         {% endif %}

--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -162,6 +162,8 @@ gcode:
             _MODULE_PRIMELINE
         {% elif action == "extruder_preheating" %}
             _MODULE_EXTRUDER_PREHEATING
+        {% elif action == "cartographer_touch" %}
+            _MODULE_CARTOGRAPHER_TOUCH
         {% elif action == "custom1" %}
             _MODULE_CUSTOM1 {rawparams}
         {% elif action == "custom2" %}
@@ -418,13 +420,21 @@ gcode:
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
     {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set probe_type_enabled = printer["gcode_macro _USER_VARIABLES"].probe_type_enabled %}
 
     {% if bed_mesh_enabled %}
         {% if BED_MESH_PROFILE == "" %}
             {% if verbose %}
                 RESPOND MSG="Bed mesh measurement..."
             {% endif %}
-            ADAPTIVE_BED_MESH SIZE={FL_SIZE}
+            # If a Cartographer3D V3 is used, the bed mesh is so fast, an adaptive bed mesh
+            # isn't worth it. Also the Cartographer 3D documentation advises against an
+            # adaptive bed mesh.
+            {% if probe_type_enabled == "cartographer_touch" %}
+                BED_MESH_CALIBRATE
+            {% else %}
+                ADAPTIVE_BED_MESH SIZE={FL_SIZE}
+            {% endif %}
         {% else %}
             {% if verbose %}
                 RESPOND MSG="Load bed mesh profile : {BED_MESH_PROFILE}"
@@ -449,7 +459,12 @@ gcode:
         RESPOND MSG="Pre-heating the nozzle to a safe temperature..."
     {% endif %}
 
-    {% if probe_type_enabled == "vorontap" %}
+    # If we have a cartographer touch, we wouldn't necessarily need to wait for the
+    # extruder preheating to finish now, but if we didn't we would have to wait
+    # for the preheating to finish before clean or some such. And then we would need
+    # to introduce a print start action "extruder_preheating_wait" to be placed in front
+    # of clean, which might not be worth it.
+    {% if probe_type_enabled == "vorontap" or probe_type_enabled == "cartographer_touch" %}
         M109 S{safe_extruder_temp}
         {% if verbose %}
             RESPOND MSG="Extruder at safe temperature of {safe_extruder_temp} degrees"
@@ -467,6 +482,43 @@ gcode:
         {% endif %}
     {% endif %}
 
+[gcode_macro _MODULE_CARTOGRAPHER_TOUCH]
+gcode:
+    # Preheat the nozzle to safe probing temperature.
+    {% set probe_type_enabled = printer["gcode_macro _USER_VARIABLES"].probe_type_enabled %}
+    {% set cartographer_touch_max_probing_temp = printer["gcode_macro _USER_VARIABLES"].cartographer_touch_max_probing_temp|float %}
+    {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
+
+    {% if probe_type_enabled == "cartographer_touch" %}
+        SAVE_GCODE_STATE NAME=BEFORE_CARTOGRAPHER_TOUCH_ACTION
+
+        {% set ACTUAL_TEMP = printer.extruder.temperature %}
+        {% set TARGET_TEMP = printer.extruder.target %}
+
+        {% if TARGET_TEMP > cartographer_touch_max_probing_temp %}
+            { action_respond_info('Extruder temperature target of %.1fC is too high for Cartographer 3D touching, lowering to %.1fC' % (TARGET_TEMP, cartographer_touch_max_probing_temp)) }
+            M106 S255 ; 100% the part cooling fan to help the extruder cooling
+            M109 S{cartographer_touch_max_probing_temp}
+            M106 S0   ; Stop the part cooling fan
+        {% else %}
+            # Temperature target is already low enough, but nozzle may still be too hot
+            {% if ACTUAL_TEMP > cartographer_touch_max_probing_temp + 3 %}
+                M106 S255 ; 100% the part cooling fan to help the extruder cooling
+                TEMPERATURE_WAIT SENSOR=extruder MAXIMUM={cartographer_touch_max_probing_temp}
+                M106 S0   ; Stop the part cooling fan
+            {% endif %}
+        {% endif %}
+
+        CARTOGRAPHER_TOUCH
+
+        # Restore target temperature. We don't need a z hop as CARTOGRAPHER_TOUCH will leave us with some distance
+        # to the PEI
+        M109 S{TARGET_TEMP}
+
+        RESTORE_GCODE_STATE NAME=BEFORE_CARTOGRAPHER_TOUCH_ACTION
+    {% elif verbose %}
+        RESPOND MSG="No Cartographer3D probe installed, skipping cartographer_touch."
+    {% endif %}
 
 [gcode_macro _MODULE_CUSTOM1]
 gcode:

--- a/macros/miscs/startup.cfg
+++ b/macros/miscs/startup.cfg
@@ -118,6 +118,8 @@ gcode:
             { action_raise_error("Inductive probe and Z calibration plugin cannot be used at the same time in Klippain!") }
         {% elif probe_type_enabled == "dockable_virtual" or probe_type_enabled == "inductive_virtual" %}
             { action_raise_error("Virtual Z endstop probes are not compatible with the Z calibration plugin!") }
+        {% elif probe_type_enabled == "cartographer_touch" %}
+            { action_raise_error("Cartographer3D Probe with Touch and Z calibration plugin cannot be used at the same time in Klippain!") }
         {% elif probe_type_enabled == "none" %}
             { action_raise_error("You need a probe to use the Z calibration plugin in Klippain!") }
         {% endif %}

--- a/moonraker/cartographer.conf
+++ b/moonraker/cartographer.conf
@@ -1,0 +1,9 @@
+[update_manager cartographer]
+type: git_repo
+path: ~/cartographer-klipper
+channel: stable
+origin: https://github.com/Cartographer3D/cartographer-klipper.git
+is_system_service: False
+managed_services: klipper
+info_tags:
+  desc=Cartographer Probe

--- a/moonraker/cartographer_cn.conf
+++ b/moonraker/cartographer_cn.conf
@@ -1,0 +1,9 @@
+[update_manager cartographer]
+type: git_repo
+path: ~/cartographer-klipper
+channel: stable
+origin: https://gitee.com/NBTP/cartographer-klipper.git
+is_system_service: False
+managed_services: klipper
+info_tags:
+  desc=Cartographer Probe (Gitee)

--- a/user_templates/moonraker.conf
+++ b/user_templates/moonraker.conf
@@ -38,6 +38,12 @@
 # server: http://YourSpoolmanIP:7912
 # -----------------------------------------------------------------
 
+##### Cartographer plugin update management
+# [include moonraker/cartographer.conf]
+
+##### Cartographer plugin update management (if you are in Mainland China)
+# [include moonraker/cartographer_cn.conf]
+
 ##### led_effect plugin update management  ------------------------
 # [include moonraker/led_effect.conf]
 # -----------------------------------------------------------------

--- a/user_templates/printer.cfg
+++ b/user_templates/printer.cfg
@@ -304,6 +304,33 @@
 # ----------------------------------------------------------------------------------------
 
 
+# -------------------------------------------------------------------------- CARTOGRAPHER 3D ----
+### --------------------------------------------------------------------------------------
+### You must have the Cartographer3D plugin installed... from here:
+### https://github.com/Cartographer3D/cartographer-klipper.git
+### (or if you are in Mainland China https://gitee.com/NBTP/cartographer-klipper.git)
+### be sure you did run ~/cartographer-klipper/install.sh after downloading it.
+### This is for the Cartographer 3D with Touch!
+
+###
+### ATTENTION: Be sure to do the calibration steps described in
+###            https://docs.cartographer3d.com/cartographer-probe/installation-and-setup/installation/calibration
+###            You will have to override the `y_offset` and `backlash_comp` settings in
+###            the `[scanner]` section.
+###
+
+# [mcu scanner]
+## In case you use canbus
+## determine canbus uuid by ~/klippy-env/bin/python ~/klipper/scripts/canbus_query.py can0
+## an example for a canbus uuid is: 0ca8d67388c2 YOURS WILL BE MOST CERTAINLY DIFFERENT
+# canbus_uuid: <uuid>
+## In case you use usb determine serial by ls /dev/serial/by_id
+## an example of a serial is /dev/serial/by-id/usb-cartographer_cartographer_ YOURS WILL BE MOST CERTAINLY DIFFERENT
+# serial: <serial>
+
+# [include config/hardware/probes/cartographer_v3_virtual.cfg]
+# [include config/hardware/accelerometers/cartographer_v3_accelerometer.cfg]
+
 
 ###################################
 ### DO NOT EDIT BELOW THIS LINE ###

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -140,6 +140,11 @@ variable_autodock_on_probe_error: True
 variable_tap_max_probing_temp: 150
 variable_tap_deactivation_zhop: 5 # this is used to Z hop before restoring the temperature to avoid burnt PEI
 
+#####################################################################
+# Cartographer3D Touch probe variables (if available in the machine)
+#####################################################################
+
+variable_cartographer_touch_max_probing_temp: 150
 
 ##########################################
 # Material and specific print parameters


### PR DESCRIPTION
This adds configuration for a Cartographer 3D with Touch enabled and an adxl accelerometer.

Please give it a thorough review, as its my first work on such stuff, which I didn't do only for myself.

Reasons for some of the decisions I made:

We need to be able to override some settings for
`[bed_mesh]` so the include in `user_templates/printer.cfg` is placed after the bed mesh definitions and not
in the probe section.

Cartographer3D V3 doesn't touch the bed with the nozzle except for the `CARTOGRAPHER_TOUCH` command. Therefore we need to pay attention to the nozzle temperature for that. But not for all the other actions like
homing or quad gantry leveling or some such.

The documentation for Cartographer3D advises against an adaptive bed mesh and the full bed mesh will
be fast enough in most cases, so we deactivated
the adaptive bed mesh if a Cartographer3D probe
is used. Maybe this should be configurable? Tell me, and I will alter it.

Also, what do you think about `variable_cartographer_touch_max_probing_temp` maybe I should simply use
`variable_safe_extruder_temp` instead?

This would make it easier and more backwards compatible. But for now I took inspiration
from `variable_tap_max_probing_temp`.