### PR TITLE
Show chamber temp on old school displays and tweak menu structure

### DIFF
--- a/config/hardware/temperature_sensors/chamber_temp.cfg
+++ b/config/hardware/temperature_sensors/chamber_temp.cfg
@@ -9,3 +9,6 @@ gcode:
 [temperature_sensor Chamber]
 sensor_type: ATC Semitec 104GT-2
 sensor_pin: CHAMBER_TEMPERATURE
+
+# Include adaptations to the menus
+[include ../../../config/software/display/display_chamber_temp.cfg]

--- a/config/hardware/temperature_sensors/chamber_temp_ds18b20.cfg
+++ b/config/hardware/temperature_sensors/chamber_temp_ds18b20.cfg
@@ -15,3 +15,6 @@ gcode:
 sensor_type: DS18B20
 sensor_mcu: rpi
 serial_no: override-me-to-the-correct-serial
+
+# Include adaptations to the menus
+[include ../../../config/software/display/display_chamber_temp.cfg]

--- a/config/hardware/temperature_sensors/chamber_temp_toolhead.cfg
+++ b/config/hardware/temperature_sensors/chamber_temp_toolhead.cfg
@@ -9,3 +9,6 @@ gcode:
 [temperature_sensor Chamber]
 sensor_type: ATC Semitec 104GT-2
 sensor_pin: toolhead:CHAMBER_TEMPERATURE
+
+# Include adaptations to the menus
+[include ../../../config/software/display/display_chamber_temp.cfg]

--- a/config/software/display/display.cfg
+++ b/config/software/display/display.cfg
@@ -143,3 +143,169 @@ index: 3
 name: Clean Nozzle
 gcode:
   CLEAN_NOZZLE
+
+# Require confirmation for anything that would abort an in-progress print.
+# Steppers off
+[menu __main __control __disable]
+type: command
+name: Steppers off
+enable: {printer.idle_timeout.state != "Printing"}
+gcode:
+  M84
+  M18
+
+[menu __main __control __disable_printing]
+type: list
+index: 3
+enable: {printer.idle_timeout.state == "Printing"}
+name: Steppers off
+
+[menu __main __control __disable_printing __confirm]
+type: command
+name: Confirm steppers off
+gcode:
+  M84
+  M18
+  {menu.back()}
+
+
+[menu __main __sdcard __start]
+type: command
+enable: {('virtual_sdcard' in printer) and printer.virtual_sdcard.file_path and not printer.virtual_sdcard.is_active and
+         (printer.print_stats.state != "printing" or printer.print_stats.state != "paused")}
+name: Start printing
+gcode: M24
+
+# SD card cancel
+[menu __main __sdcard __cancel]
+type: list
+enable: {('virtual_sdcard' in printer) and
+         (printer.print_stats.state == "printing" or
+          printer.print_stats.state == "paused")}
+name: Cancel printing
+
+[menu __main __sdcard __cancel __confirm]
+type: command
+name: Confirm cancel printing
+gcode:
+  CANCEL_PRINT
+  {menu.back()}
+
+[menu __main __control __home]
+type: input
+enable: {not printer.print_stats.state == "printing" }
+name: Home: {['ALL','Z','X Y', 'Non'][menu.input|int]}
+input: 0
+input_min: 0
+input_max: 3
+gcode: {['G28','G28 Z','G28 X Y',''][menu.input|int]}
+index: 1
+
+[menu __main __control __fan]
+type: list
+name: Fan 
+index: 9
+
+[menu __main __control __fan __partcooling]
+type: list
+enable: {'fan' in printer}
+name: Cooling {'%3d%s' % (printer.fan.speed*100,'%') if printer.fan.speed else 'OFF'}
+
+[menu __main __control __fan __partcooling __fanonoff]
+type: input
+name: Toggle: {'ON' if menu.input else 'OFF'}
+input: {printer.fan.speed}
+input_min: 0
+input_max: 1
+input_step: 1
+gcode: M106 S{255 if menu.input else 0}
+
+[menu __main __control __fan __partcooling __fanspeed]
+type: input
+name: Speed:  {'%3d%s' % (menu.input*100,'%') if menu.input else 'OFF'}
+input: {printer.fan.speed}
+input_min: 0
+input_max: 1
+input_step: 0.01
+gcode: M106 S{'%d' % (menu.input*255)}
+
+[menu __main __control __fan __filter]
+type: list
+enable: {'fan_generic filter' in printer}
+name: Filter  {'%3d%s' % (printer['fan_generic filter'].speed*100,'%') if printer['fan_generic filter'].speed else 'OFF'}
+
+[menu __main __control __fan __filter __filteronoff]
+type: input
+name: Toggle: {'ON ' if menu.input else 'OFF'}
+input: {printer['fan_generic filter'].speed}
+input_min: 0
+input_max: 1
+input_step: 1
+gcode: {% if menu.input %} START_FILTER {% else %} STOP_FILTER {% endif %}
+
+[menu __main __control __fan __filter __filterspeed]
+type: input
+name: Speed:  {'%3d%s' % (menu.input*100,'%') if menu.input else 'OFF'}
+input: {printer['fan_generic filter'].speed}
+input_min: 0
+input_max: 1
+input_step: 0.01
+gcode: SET_FAN_SPEED FAN=filter SPEED={menu.input}
+
+[menu __main __control __fan __exhaust]
+type: list
+enable: {'fan_generic exhaust' in printer}
+name: Exhaust  {'%3d%s' % (printer['fan_generic exhaust'].speed*100,'%') if printer['fan_generic exhaust'].speed else 'OFF'}
+
+[menu __main __control __fan __exhaust __exhaustonoff]
+type: input
+name: Toggle: {'ON ' if menu.input else 'OFF'}
+input: {printer['fan_generic exhaust'].speed}
+input_min: 0
+input_max: 1
+input_step: 1
+gcode: {% if menu.input %} START_EXHAUST {% else %} STOP_EXHAUST {% endif %}
+
+[menu __main __control __fan __exhaust __exhaustspeed]
+type: input
+name: Speed:  {'%3d%s' % (menu.input*100,'%') if menu.input else 'OFF'}
+input: {printer['fan_generic exhaust'].speed}
+input_min: 0
+input_max: 1
+input_step: 0.01
+gcode: SET_FAN_SPEED FAN=exhaust SPEED={menu.input}
+
+
+#Disable old Control
+[menu __main __control __homez]
+type: command
+enable: 0
+name: Home Z
+gcode: G28 Z
+
+[menu __main __control __homexy]
+type: command
+enable: 0
+name: Home X/Y
+gcode: G28 X Y
+
+[menu __main __control __fanonoff]
+type: input
+enable: 0
+name: Fan: {'ON ' if menu.input else 'OFF'}
+input: {printer.fan.speed}
+input_min: 0
+input_max: 1
+input_step: 1
+gcode:
+    M106 S{255 if menu.input else 0}
+
+[menu __main __control __fanspeed]
+type: input
+enable: 0
+name: Fan speed: {'%3d' % (menu.input*100)}%
+input: {printer.fan.speed}
+input_min: 0
+input_max: 1
+input_step: 0.01
+gcode:

--- a/config/software/display/display_chamber_temp.cfg
+++ b/config/software/display/display_chamber_temp.cfg
@@ -1,0 +1,132 @@
+[display_glyph chamber]
+data:
+    ................
+    ****************
+    *....*....*....*
+    *....*....*....*
+    *....******....*
+    *..............*
+    *..............*
+    *.....****.....*
+    *.***.*..*.***.*
+    *.....****.....*
+    *......**......*
+    *..............*
+    *.************.*
+    *...*......*...*
+    ****************
+    ................
+
+[display_glyph voron]
+data:
+   .......**.......
+   .....******.....
+   ....********....
+   ..************..
+   .*****..**..***.
+   .****..**..****.
+   .***..**..*****.
+   .**..**..******.
+   .******..**..**.
+   .*****..**..***.
+   .****..**..****.
+   .***..**..*****.
+   ..************..
+   ....********....
+   .....******.....
+   .......**.......
+
+[display]
+display_group: __voron_display
+
+[display_template _vheater_temperature]
+param_heater_name: "extruder"
+text:
+  {% if param_heater_name in printer %}
+    {% set heater = printer[param_heater_name] %}
+    # Show glyph
+    {% if param_heater_name == "heater_bed" %}
+      {% if heater.target %}
+        {% set frame = (printer.toolhead.estimated_print_time|int % 2) + 1 %}
+        ~bed_heat{frame}~
+      {% else %}
+        ~bed~
+      {% endif %}
+    {% else %}
+      ~extruder~
+    {% endif %}
+    # Show temperature
+    { "%3.0f" % (heater.temperature,) }
+    # Optionally show target
+    {% if heater.target and (heater.temperature - heater.target)|abs > 2 %}
+      ~right_arrow~
+      { "%0.0f" % (heater.target,) }
+    {% endif %}
+    ~degrees~
+  {% endif %}
+
+[display_data __voron_display extruder]
+position: 0, 0
+text: { render("_vheater_temperature", param_heater_name="extruder") }
+
+[display_data __voron_display fan]
+position: 0, 10
+text:
+  {% if 'fan' in printer %}
+    {% set speed = printer.fan.speed %}
+    {% if speed %}
+      {% set frame = (printer.toolhead.estimated_print_time|int % 2) + 1 %}
+      ~fan{frame}~
+    {% else %}
+      ~fan1~
+    {% endif %}
+    { "{:>4.0%}".format(speed) }
+  {% endif %}
+
+[display_data __voron_display bed]
+position: 1, 0
+text: { render("_vheater_temperature", param_heater_name="heater_bed") }
+
+[display_data __voron_display progress_text]
+position: 1, 10
+text:
+  {% set progress = printer.display_status.progress %}
+  { "{:^6.0%}".format(progress) }
+  
+[display_data __voron_display progress_text2]
+position: 1, 10
+text:
+  {% set progress = printer.display_status.progress %}
+  { draw_progress_bar(1, 10, 6, progress) }
+
+[display_data __voron_display printing_time]
+position: 2, 10
+text:
+  {% set ptime = printer.idle_timeout.printing_time %}
+  { "%02d:%02d" % (ptime // (60 * 60), (ptime // 60) % 60) }
+
+#########################################################
+# This section defines the actual chamber temp. field,
+# replace 'temperature_sensor chamber' as necessary
+#########################################################
+[display_data __voron_display chamber]
+position: 2, 0
+text:
+  {% set chamber = printer['temperature_sensor Chamber'] %}
+	~chamber~
+	{ "%3.0f" % (chamber.temperature,) }
+	~degrees~
+
+[display_data __voron_display print_status]
+position: 3, 0
+text: 
+  {% if printer.display_status.message %}
+    { printer.display_status.message }
+  {% elif printer.idle_timeout.printing_time %}
+    {% set pos = printer.toolhead.position %}
+    { "X%-4.0fY%-4.0fZ%-5.2f" % (pos.x, pos.y, pos.z) }
+  {% else %}
+    { "V2.6474" }
+	~voron~
+    { "Elias23" } ## TODO variable or something
+  {% endif %}


### PR DESCRIPTION
This PR has two components

- If the user has a chamber temp sensor the display now uses the main ui described [here](https://docs.vorondesign.com/community/howto/alchemyEngine/chamber_temperature_exhaust_fan.html#display-configuration). There is a TODO to make the default info line configurable currently it's set to my voron serial.
- Restructure the ui menus inspired by/based on [this repo](https://github.com/jschuh/klipper-macros/blob/main/optional/lcd_menus.cfg)