### PR TITLE
Add variable for startup light intensity

### DIFF
--- a/macros/miscs/startup.cfg
+++ b/macros/miscs/startup.cfg
@@ -58,9 +58,9 @@ gcode:
 [gcode_macro _INIT_LEDS]
 gcode:
     {% if printer["gcode_macro _USER_VARIABLES"].status_leds_enabled or printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
-        {% if printer["gcode_macro _USER_VARIABLES"].caselight_on_at_startup|default(False) %}
+        {% if printer["gcode_macro _USER_VARIABLES"].light_intensity_startup|default(0) %}
             {% if printer["gcode_macro _USER_VARIABLES"].light_enabled %}
-                LIGHT_ON
+                LIGHT_ON S={light_intensity_startup}
             {% endif %}
             STATUS_LEDS COLOR="READY"
         {% else %}

--- a/macros/miscs/startup.cfg
+++ b/macros/miscs/startup.cfg
@@ -59,7 +59,7 @@ gcode:
 gcode:
     {% if printer["gcode_macro _USER_VARIABLES"].status_leds_enabled or printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
         {% if printer["gcode_macro _USER_VARIABLES"].caselight_on_at_startup|default(False) %}
-            {% set  printer["gcode_macro _USER_VARIABLES"].light_intensity_startup|default(100) %}
+            {% set light_intensity_startup = printer["gcode_macro _USER_VARIABLES"].light_intensity_startup|default(100) %}
             {% if printer["gcode_macro _USER_VARIABLES"].light_enabled %}
                 LIGHT_ON S={light_intensity_startup}
             {% endif %}

--- a/macros/miscs/startup.cfg
+++ b/macros/miscs/startup.cfg
@@ -58,7 +58,7 @@ gcode:
 [gcode_macro _INIT_LEDS]
 gcode:
     {% if printer["gcode_macro _USER_VARIABLES"].status_leds_enabled or printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
-        {% if printer["gcode_macro _USER_VARIABLES"].light_intensity_startup|default(0) %}
+        {% set light_intensity_startup = printer["gcode_macro _USER_VARIABLES"].light_intensity_startup|default(0) %}
             {% if printer["gcode_macro _USER_VARIABLES"].light_enabled %}
                 LIGHT_ON S={light_intensity_startup}
             {% endif %}

--- a/macros/miscs/startup.cfg
+++ b/macros/miscs/startup.cfg
@@ -58,7 +58,8 @@ gcode:
 [gcode_macro _INIT_LEDS]
 gcode:
     {% if printer["gcode_macro _USER_VARIABLES"].status_leds_enabled or printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
-        {% set light_intensity_startup = printer["gcode_macro _USER_VARIABLES"].light_intensity_startup|default(0) %}
+        {% if printer["gcode_macro _USER_VARIABLES"].caselight_on_at_startup|default(False) %}
+            {% set  printer["gcode_macro _USER_VARIABLES"].light_intensity_startup|default(100) %}
             {% if printer["gcode_macro _USER_VARIABLES"].light_enabled %}
                 LIGHT_ON S={light_intensity_startup}
             {% endif %}

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -243,13 +243,13 @@ variable_purge_ooze_time: 10 # Time (in seconds) to wait after the purge to let 
 variable_purgeclean_servo_angle_retracted: 0
 variable_purgeclean_servo_angle_deployed: 90
 
-## White light parameters (if installed in the machine)
+## Caselight LEDs ON at startup (caselight need to be installed in the machine)
+variable_light_intensity_startup: 0
+
+## Caselight parameters (if installed in the machine)
 variable_light_intensity_start_print: 100
 variable_light_intensity_printing: 30
 variable_light_intensity_end_print: 0
-
-## Caselight LEDs ON at startup (caselight need to be installed in the machine)
-variable_caselight_on_at_startup: False
 
 ## Patch the M190/M109 commands to avoid some wait time while the temperature
 ## settle on very low thermal latency devices (such as the BambuLabs hotend)

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -244,9 +244,10 @@ variable_purgeclean_servo_angle_retracted: 0
 variable_purgeclean_servo_angle_deployed: 90
 
 ## Caselight LEDs ON at startup (caselight need to be installed in the machine)
-variable_light_intensity_startup: 0
+variable_caselight_on_at_startup: False
 
 ## Caselight parameters (if installed in the machine)
+variable_light_intensity_startup: 100
 variable_light_intensity_start_print: 100
 variable_light_intensity_printing: 30
 variable_light_intensity_end_print: 0


### PR DESCRIPTION
Added a variable to allow light intensity to be controlled to a user set value on klipper startup, similar to the control of light intensity for start and end print. 