### PR TITLE
[BUGFIX] Missing retract_length variable in END_PRINT

### DIFF
--- a/macros/base/end_print.cfg
+++ b/macros/base/end_print.cfg
@@ -17,7 +17,6 @@ gcode:
     {% set filter_default_time = printer["gcode_macro _USER_VARIABLES"].filter_default_time_on_end_print|default(600)|int %}
     {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
     {% set hotend_fan_tach_enabled = printer["gcode_macro _USER_VARIABLES"].hotend_fan_tach_enabled %}
-    {% set retract_length = printer["gcode_macro _USER_VARIABLES"].retract_length|default(20)|float %}
 
     PARK
 
@@ -93,9 +92,10 @@ gcode:
 [gcode_macro _MODULE_RETRACT_FILAMENT]
 gcode:
     # ----- RETRACT FILAMENT -------------------------------------
-    # Retract filament for easier swaps at the end of a print job 
+    # Retract filament for easier swaps at the end of a print job
     {% set klippain_mmu_enabled = printer["gcode_macro _USER_VARIABLES"].klippain_mmu_enabled %}
     {% set mmu_unload = params.MMU_UNLOAD_AT_END|default(printer["gcode_macro _USER_VARIABLES"].mmu_unload_on_end_print)|default(0)|int %}
+    {% set retract_length = printer["gcode_macro _USER_VARIABLES"].retract_length|default(20)|float %}
 
     {% if klippain_mmu_enabled %}
         {% if printer.mmu.enabled and mmu_unload %}


### PR DESCRIPTION
Moving the variable into the _MODULE_RETRACT_FILAMENT macro was missed when refactoring the END_PRINT setup
