### PR TITLE
[BUGFIX] Low temp check: heat up extruder if below min_extrude_temp

### DIFF
--- a/macros/helpers/temp_check.cfg
+++ b/macros/helpers/temp_check.cfg
@@ -2,8 +2,9 @@
 description: Check the nozzle is at temperature and heat it if needed
 gcode: 
     {% set T = params.T|default(printer["gcode_macro _USER_VARIABLES"].print_default_extruder_temp)|float %}
+    {% set MIN_EXTRUDE_TEMP = printer.configfile.config.extruder.min_extrude_temp|float %}
 
-    {% if printer.extruder.target != 0 %}
+    {% if printer.extruder.target != 0 and printer.extruder.target >= MIN_EXTRUDE_TEMP %}
         {% if printer.extruder.temperature < printer.extruder.target %}
             M109 S{printer.extruder.target|float} 
         {% endif %}


### PR DESCRIPTION
In the case that the extruder target temp is >0 but below the min extrude temp the current check fails to heat up the nozzle to a temperature where it's possible to oxtrude.

How to reproduce:

1) Set extruder temp to 150C
2) Try to load / unload filament
3) No heat up will be performed / error about extruder temp too low will be shown.
