### PR TITLE
Pinout fix for Leviathan MCU config - Board v1.2 and v1.3 pinout compatible

### DIFF
--- a/config/mcu_definitions/main/LDO_Leviathan_v1.x.cfg
+++ b/config/mcu_definitions/main/LDO_Leviathan_v1.x.cfg
@@ -20,7 +20,7 @@ aliases:
     MCU_T0=PA1, MCU_T1=PA2, MCU_T2=PA0, MCU_T3=PA3,
 
     MCU_FAN0=PB7, MCU_FAN1=PB3, MCU_FAN2=PF7, MCU_FAN3=PF9,
-    MCU_FAN0_TACHO=PB0, MCU_FAN1_TACHO=PB4, MCU_FAN2_TACHO=PF6, MCU_FAN3_TACHO=PF8,
+    MCU_FAN0_TACHO=PB8, MCU_FAN1_TACHO=PB4, MCU_FAN2_TACHO=PF6, MCU_FAN3_TACHO=PF8,  # Fixed "PB0" (GPIO 13) > "PB8" (Fan0) v1.2&.3 docs
 
     MCU_NEOPIXEL=PF10,
     MCU_LED=PE6,
@@ -37,7 +37,7 @@ aliases:
 
     # EXP2 header
     EXP2_1=PA6   , EXP2_2=PA5   ,
-    EXP2_3=PE2   , EXP2_4=PE4   ,
+    EXP2_3=PE2   , EXP2_4=PA4   ,  # Fixed "PE4" (Kill) > "PA4" (SPI_CS) 1.2&.3 docs
     EXP2_5=PE3   , EXP2_6=PA7   ,  # Slot in the socket on this side
     EXP2_7=PE5   , EXP2_8=<RST> ,
     EXP2_9=<GND> , EXP2_10=PE4  ,


### PR DESCRIPTION
LDO_Leviathan_v1.2.cfg Renamed ..._v1.x.cfg - pinout the same for v1.2 and v1.3 boards. Controller update on v1.3 - may need additional testing.

Fixed Fan0 Tacho (PB0 > PB8) and EXP2 SPI_CS (PE4 > PA4) from official LDO Leviathan manuals v1.2 and v1.3 - both crosschecked.

Ref: https://github.com/MotorDynamicsLab/Leviathan/tree/master/Manual