### PR TITLE
[BUGFIX] START_PRINT: disable filament sensor

### DIFF
--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -209,7 +209,7 @@ gcode:
         START_FILTER SPEED={material.filter_speed / 100}
     {% endif %}
 
-    {% if filament_sensor_enabled %}
+    {% if filament_sensor_enabled and not material.filament_sensor %}
         SET_FILAMENT_SENSOR SENSOR="runout_sensor" ENABLE=0
     {% endif %}
 


### PR DESCRIPTION
The condition to disable the filament sensor is missing the material properties check.
