### PR TITLE
fix: Comment out unsupported run_on_error parameter in LED effects

### DIFF
--- a/config/hardware/lights/status_leds_effects.cfg
+++ b/config/hardware/lights/status_leds_effects.cfg
@@ -228,4 +228,4 @@ layers:
     static         1  0     top        (1.0,  0.0, 0.0)
 autostart:                             false
 frame_rate:                            24
-run_on_error:                          true
+# run_on_error:                          true  # Not supported without patched MCU firmware

--- a/config/hardware/lights/status_leds_rainbow_barf_effects.cfg
+++ b/config/hardware/lights/status_leds_rainbow_barf_effects.cfg
@@ -228,4 +228,4 @@ layers:
     static         1  0     top        (1.0,  0.0, 0.0)
 autostart:                             false
 frame_rate:                            24
-run_on_error:                          true
+# run_on_error:                          true  # Not supported without patched MCU firmware


### PR DESCRIPTION
The run_on_error parameter is not supported in klipper-led_effect without patched MCU firmware. Recent Klipper updates enforce stricter configuration validation, causing these files to fail when loading.

This change comments out the run_on_error parameter in both LED effects configuration files with a clear explanation that it requires patched firmware to function.

The critical_error LED effect remains defined and can be manually triggered, but will not auto-activate on errors without the firmware patch.

Fixes compatibility with recent Klipper versions.

🤖 supported by [Claude Code](https://claude.com/claude-code)