### PR TITLE
Off below to min power

### DIFF
--- a/config/hardware/filters/nevermore_filter.cfg
+++ b/config/hardware/filters/nevermore_filter.cfg
@@ -12,6 +12,6 @@ gcode:
 pin: FILTER_FAN
 max_power: 1.0
 kick_start_time: 0.250
-off_below: 0.30
+min_power: 0.30
 # hardware_pwm: True
 # cycle_time: 0.001

--- a/config/hardware/filters/nevermore_filter_kalico.cfg
+++ b/config/hardware/filters/nevermore_filter_kalico.cfg
@@ -12,6 +12,6 @@ gcode:
 pin: FILTER_FAN
 max_power: 1.0
 kick_start_time: 0.250
-off_below: 0.30
+min_power: 0.30
 # hardware_pwm: True
 # cycle_time: 0.001

--- a/user_templates/printer.cfg
+++ b/user_templates/printer.cfg
@@ -212,6 +212,7 @@
 ### --------------------------------------------------------------------------------------
 # [include config/hardware/filters/exhaust_filter.cfg]
 # [include config/hardware/filters/nevermore_filter.cfg]
+# [include config/hardware/filters/nevermore_filter_kalico.cfg] # Kalico specific using min_power instead of off_below.
 # ----------------------------------------------------------------------------------------
 
 


### PR DESCRIPTION
Created a kalico specific version of the nevermore filter config as `min_power` is being depreciated for `off_below` sometime in the future.