### PR TITLE
fix: add Leviathan v1.3 defaults and correct shared pin mappings

### DIFF
--- a/config/mcu_definitions/main/LDO_Leviathan_v1.2.cfg
+++ b/config/mcu_definitions/main/LDO_Leviathan_v1.2.cfg
@@ -1,3 +1,5 @@
+# This MCU definition works for both V1.2 and V1.3 boards
+
 [board_pins mcu_manufacturer]
 aliases:
     MCU_HV-STEPPER0_STEP=PB10, MCU_HV-STEPPER0_DIR=PB11, MCU_HV-STEPPER0_EN=PG0, MCU_HV-STEPPER0_CS=PE15,
@@ -20,7 +22,7 @@ aliases:
     MCU_T0=PA1, MCU_T1=PA2, MCU_T2=PA0, MCU_T3=PA3,
 
     MCU_FAN0=PB7, MCU_FAN1=PB3, MCU_FAN2=PF7, MCU_FAN3=PF9,
-    MCU_FAN0_TACHO=PB0, MCU_FAN1_TACHO=PB4, MCU_FAN2_TACHO=PF6, MCU_FAN3_TACHO=PF8,
+    MCU_FAN0_TACHO=PB8, MCU_FAN1_TACHO=PB4, MCU_FAN2_TACHO=PF6, MCU_FAN3_TACHO=PF8,
 
     MCU_NEOPIXEL=PF10,
     MCU_LED=PE6,
@@ -37,7 +39,7 @@ aliases:
 
     # EXP2 header
     EXP2_1=PA6   , EXP2_2=PA5   ,
-    EXP2_3=PE2   , EXP2_4=PE4   ,
+    EXP2_3=PE2   , EXP2_4=PA4   ,
     EXP2_5=PE3   , EXP2_6=PA7   ,  # Slot in the socket on this side
     EXP2_7=PE5   , EXP2_8=<RST> ,
     EXP2_9=<GND> , EXP2_10=PE4  ,

--- a/user_templates/mcu_defaults/main/LDO_Leviathan_v1.3.cfg
+++ b/user_templates/mcu_defaults/main/LDO_Leviathan_v1.3.cfg
@@ -1,0 +1,53 @@
+
+#--------------------------------------#
+#### LDO Leviathan MCU definition ######
+#--------------------------------------#
+
+[mcu]
+##--------------------------------------------------------------------
+# This board work by using a serial connection by default. If you
+# want to use CAN, invert the commented lines and use canbus_uuid.
+
+serial: /dev/serial/by-id/change-me-to-the-correct-mcu-path
+# canbus_uuid: change-me-to-the-correct-canbus-id
+##--------------------------------------------------------------------
+
+[include config/mcu_definitions/main/LDO_Leviathan_v1.2.cfg] # Do not remove this line - works for both V1.2 and V1.3 boards
+[board_pins leviathan_mcu]
+mcu: mcu
+aliases:
+    X_STEP=MCU_HV-STEPPER0_STEP , X_DIR=MCU_HV-STEPPER0_DIR , X_ENABLE=MCU_HV-STEPPER0_EN   , X_TMCUART=MCU_HV-STEPPER0_CS  ,
+    Y_STEP=MCU_HV-STEPPER1_STEP , Y_DIR=MCU_HV-STEPPER1_DIR , Y_ENABLE=MCU_HV-STEPPER1_EN   , Y_TMCUART=MCU_HV-STEPPER1_CS  ,
+
+    DRIVER_SPI_MOSI=MCU_SPI2_MOSI , # Used for TMC5160 (HV-STEPPER0 and HV-STEPPER1)
+    DRIVER_SPI_MISO=MCU_SPI2_MISO , # Used for TMC5160 (HV-STEPPER0 and HV-STEPPER1)
+    DRIVER_SPI_SCK=MCU_SPI2_SCK   , # Used for TMC5160 (HV-STEPPER0 and HV-STEPPER1)
+
+    Z_STEP=MCU_STEPPER0_STEP    , Z_DIR=MCU_STEPPER0_DIR    , Z_ENABLE=MCU_STEPPER0_EN      , Z_TMCUART=MCU_STEPPER0_UART   ,
+    Z1_STEP=MCU_STEPPER1_STEP   , Z1_DIR=MCU_STEPPER1_DIR   , Z1_ENABLE=MCU_STEPPER1_EN     , Z1_TMCUART=MCU_STEPPER1_UART  ,
+    Z2_STEP=MCU_STEPPER2_STEP   , Z2_DIR=MCU_STEPPER2_DIR   , Z2_ENABLE=MCU_STEPPER2_EN     , Z2_TMCUART=MCU_STEPPER2_UART  ,
+    Z3_STEP=MCU_STEPPER3_STEP   , Z3_DIR=MCU_STEPPER3_DIR   , Z3_ENABLE=MCU_STEPPER3_EN     , Z3_TMCUART=MCU_STEPPER3_UART  ,
+
+    E_STEP=MCU_STEPPER4_STEP    , E_DIR=MCU_STEPPER4_DIR    , E_ENABLE=MCU_STEPPER4_EN      , E_TMCUART=MCU_STEPPER4_UART   ,
+
+    X_STOP=MCU_STOP_X           , Y_STOP=MCU_STOP_Y         , Z_STOP=MCU_STOP_Z,
+    PROBE_INPUT=MCU_Z_PROBE,
+    RUNOUT_SENSOR=MCU_STOP_E0,
+
+    E_HEATER=MCU_HE0            , E_TEMPERATURE=MCU_T1      ,
+    BED_HEATER=MCU_BED0         , BED_TEMPERATURE=MCU_T0    ,
+
+    PART_FAN=MCU_FAN0           , E_FAN=MCU_FAN1            ,
+    CONTROLLER_FAN=MCU_FAN2     ,
+    EXHAUST_FAN=MCU_FAN3        ,
+
+    CHAMBER_TEMPERATURE=MCU_T2  , ELECTRICAL_CABINET_TEMPERATURE=MCU_T3,
+
+    LIGHT_OUTPUT=MCU_LED        ,
+    STATUS_NEOPIXEL=MCU_NEOPIXEL,
+
+[heater_bed]
+pullup_resistor: 2200
+
+[extruder]
+pullup_resistor: 2200


### PR DESCRIPTION
Add a mainboard user template for the LDO Leviathan v1.3 so it can be selected like the other supported boards.

Also correct the shared manufacturer mapping used by both v1.2 and v1.3 boards by fixing the FAN0 tach pin and the EXP2_4 pin. This keeps the reusable base definition accurate for both revisions and documents that the same MCU definition applies to each board.

Closes: #717 
