### PR TITLE
feat: Virtual Z probing framework

### DIFF
--- a/config/hardware/probes/beacon_contact.cfg
+++ b/config/hardware/probes/beacon_contact.cfg
@@ -11,12 +11,20 @@
 [gcode_macro _USER_VARIABLES]
 # We can declare an "inductive_virtual" probe type as it's pretty close to the Beacon way of working and should just work!
 variable_probe_type_enabled: "beacon_contact"
-variable_startprint_actions: "bed_soak", "extruder_preheating", "chamber_soak", "clean", "beacon_calib", "tilt_calib", "bedmesh", "z_offset", "extruder_heating", "purge", "clean", "primeline"
+variable_probe_uses_virtual_z: True
+variable_probe_uses_nozzle_contact: True
+variable_probe_needs_contact_temp_guard: True
+variable_probe_hook_family: "beacon_contact"
+variable_probe_contact_z_home_mode: "hook"
+variable_probe_contact_auto_calibrate_mode: "hook"
+variable_probe_unsupported_contact_action_policy: "warn"
+variable_startprint_actions: "bed_soak", "extruder_preheating", "chamber_soak", "clean", "contact_auto_calibrate", "tilt_calib", "bedmesh", "z_offset", "extruder_heating", "purge", "clean", "primeline"
 
 gcode:
 
 # Beacon probe definition also include the probe management macros directly from here
 [include ../../../macros/base/probing/generic_probe.cfg]
+[include ../../../macros/base/probing/hooks/beacon_contact.cfg]
 [include ../../../macros/base/homing/homing_beacon_contact.cfg]
 
 [stepper_z]
@@ -37,6 +45,6 @@ home_gcode_pre_y: _HOME_PRE_AXIS AXIS=Y
 home_gcode_post_y: _HOME_POST_AXIS AXIS=Y
 home_gcode_pre_xy: _HOME_XY STAGE=pre
 home_gcode_post_xy: _HOME_XY STAGE=post
-contact_activate_gcode: ACTIVATE_PROBE
-contact_deactivate_gcode: DEACTIVATE_PROBE
+contact_activate_gcode: ACTIVATE_PROBE SOURCE=homing
+contact_deactivate_gcode: DEACTIVATE_PROBE SOURCE=homing
 contact_max_hotend_temperature: 180

--- a/config/hardware/probes/beacon_virtual.cfg
+++ b/config/hardware/probes/beacon_virtual.cfg
@@ -11,6 +11,13 @@
 [gcode_macro _USER_VARIABLES]
 # We can declare an "inductive_virtual" probe type as it's pretty close to the Beacon way of working and should just work!
 variable_probe_type_enabled: "inductive_virtual"
+variable_probe_uses_virtual_z: True
+variable_probe_uses_nozzle_contact: False
+variable_probe_needs_contact_temp_guard: False
+variable_probe_hook_family: ""
+variable_probe_contact_z_home_mode: "none"
+variable_probe_contact_auto_calibrate_mode: "none"
+variable_probe_unsupported_contact_action_policy: "warn"
 variable_startprint_actions: "bed_soak", "extruder_preheating", "chamber_soak", "tilt_calib", "extruder_heating", "purge", "clean", "z_offset", "bedmesh", "primeline"
 gcode:
 

--- a/config/hardware/probes/bltouch_virtual.cfg
+++ b/config/hardware/probes/bltouch_virtual.cfg
@@ -5,6 +5,13 @@
 
 [gcode_macro _USER_VARIABLES]
 variable_probe_type_enabled: "bltouch"
+variable_probe_uses_virtual_z: True
+variable_probe_uses_nozzle_contact: False
+variable_probe_needs_contact_temp_guard: False
+variable_probe_hook_family: ""
+variable_probe_contact_z_home_mode: "none"
+variable_probe_contact_auto_calibrate_mode: "none"
+variable_probe_unsupported_contact_action_policy: "warn"
 variable_startprint_actions: "bed_soak", "extruder_preheating", "chamber_soak", "tilt_calib", "extruder_heating", "purge", "clean", "z_offset", "bedmesh", "primeline"
 gcode:
 

--- a/config/hardware/probes/cartographer_touch.cfg
+++ b/config/hardware/probes/cartographer_touch.cfg
@@ -1,0 +1,31 @@
+# This probe type is for Cartographer Survey Touch used as a virtual Z endstop.
+# Install the Cartographer Klipper plugin and configure the scanner MCU before enabling.
+
+[gcode_macro _USER_VARIABLES]
+variable_probe_type_enabled: "cartographer_touch"
+variable_startprint_actions: "bed_soak", "extruder_preheating", "chamber_soak", "tilt_calib", "z_offset", "bedmesh", "clean", "contact_z_home", "extruder_heating", "purge", "clean", "primeline"
+variable_probe_uses_virtual_z: True
+variable_probe_uses_nozzle_contact: True
+variable_probe_needs_contact_temp_guard: True
+variable_probe_hook_family: "cartographer_touch"
+variable_probe_contact_z_home_mode: "hook"
+variable_probe_contact_auto_calibrate_mode: "none"
+variable_probe_unsupported_contact_action_policy: "warn"
+gcode:
+
+[include ../../../macros/base/homing/homing_override.cfg]
+[include ../../../macros/base/probing/generic_probe.cfg]
+[include ../../../macros/base/probing/hooks/cartographer_touch.cfg]
+
+[scanner]
+mcu: scanner
+sensor: cartographer
+sensor_alt: carto
+x_offset: 0
+y_offset: 15
+backlash_comp: 0.5
+mesh_runs: 2
+
+[stepper_z]
+endstop_pin: probe:z_virtual_endstop
+homing_retract_dist: 0

--- a/config/hardware/probes/dockable_virtual.cfg
+++ b/config/hardware/probes/dockable_virtual.cfg
@@ -5,6 +5,13 @@
 
 [gcode_macro _USER_VARIABLES]
 variable_probe_type_enabled: "dockable_virtual"
+variable_probe_uses_virtual_z: True
+variable_probe_uses_nozzle_contact: False
+variable_probe_needs_contact_temp_guard: False
+variable_probe_hook_family: ""
+variable_probe_contact_z_home_mode: "none"
+variable_probe_contact_auto_calibrate_mode: "none"
+variable_probe_unsupported_contact_action_policy: "warn"
 variable_startprint_actions: "bed_soak", "extruder_preheating", "chamber_soak", "tilt_calib", "extruder_heating", "purge", "clean", "z_offset", "bedmesh", "primeline"
 gcode:
 

--- a/config/hardware/probes/inductive_virtual.cfg
+++ b/config/hardware/probes/inductive_virtual.cfg
@@ -5,6 +5,13 @@
 
 [gcode_macro _USER_VARIABLES]
 variable_probe_type_enabled: "inductive_virtual"
+variable_probe_uses_virtual_z: True
+variable_probe_uses_nozzle_contact: False
+variable_probe_needs_contact_temp_guard: False
+variable_probe_hook_family: ""
+variable_probe_contact_z_home_mode: "none"
+variable_probe_contact_auto_calibrate_mode: "none"
+variable_probe_unsupported_contact_action_policy: "warn"
 variable_startprint_actions: "bed_soak", "extruder_preheating", "chamber_soak", "tilt_calib", "extruder_heating", "purge", "clean", "z_offset", "bedmesh", "primeline"
 gcode:
 

--- a/config/hardware/probes/voron_tap.cfg
+++ b/config/hardware/probes/voron_tap.cfg
@@ -1,5 +1,12 @@
 [gcode_macro _USER_VARIABLES]
 variable_probe_type_enabled: "vorontap"
+variable_probe_uses_virtual_z: True
+variable_probe_uses_nozzle_contact: True
+variable_probe_needs_contact_temp_guard: True
+variable_probe_hook_family: ""
+variable_probe_contact_z_home_mode: "standard_g28"
+variable_probe_contact_auto_calibrate_mode: "none"
+variable_probe_unsupported_contact_action_policy: "warn"
 variable_startprint_actions: "bed_soak", "extruder_preheating", "chamber_soak", "clean", "tilt_calib", "z_offset", "bedmesh", "extruder_heating", "purge", "clean", "primeline"
 gcode:
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -16,6 +16,7 @@ Here you can find a list of all the custom features availables in the macros or 
   - Easy [flow calibration](./features/flow_calibration.md) macro
   - Automatic [input shaper workflow](./features/is_workflow.md) to calibrate it without using SSH
   - Custom designed [vibrations measurements and calibration workflow](./features/vibr_measurements.md) to be able to do an advanced calibration of the machine speed settings and optimize your global mechanical assembly
+  - [Virtual-Z probe framework](./features/virtual_z_probes.md) for TAP, Beacon Contact, and Cartographer Survey Touch setup
   - More feature descriptions and info will be added later...
 
 

--- a/docs/features/virtual_z_probes.md
+++ b/docs/features/virtual_z_probes.md
@@ -1,0 +1,67 @@
+# Virtual-Z Probe Framework
+
+Klippain supports probes that act as the Z endstop through concrete probe profile includes. Users still select one probe include in `user_templates/printer.cfg`; the framework underneath standardizes contact temperature guarding, Z-home dispatch, and generic start-print actions.
+
+## Probe Profiles
+
+Use one probe include:
+
+```ini
+[include config/hardware/probes/voron_tap.cfg]
+[include config/hardware/probes/beacon_contact.cfg]
+[include config/hardware/probes/cartographer_touch.cfg]
+```
+
+`voron_tap.cfg` keeps the legacy internal identifier `probe_type_enabled: "vorontap"` for compatibility.
+
+## Shared Contact Variables
+
+Preferred variables:
+
+```ini
+variable_probe_contact_max_temp: 150
+variable_probe_contact_deactivation_zhop: 5
+variable_probe_unsupported_contact_action_policy: "warn"
+```
+
+Legacy variables remain supported for existing configs:
+
+```ini
+variable_tap_max_probing_temp: 150
+variable_tap_deactivation_zhop: 5
+variable_beacon_max_probing_temp: 150
+variable_beacon_deactivation_zhop: 5
+```
+
+If both shared and legacy variables are set, the shared variable wins. With verbose output enabled, Klippain reports the override at startup.
+
+## Start-Print Actions
+
+Generic actions:
+
+```ini
+contact_z_home
+contact_auto_calibrate
+```
+
+`contact_z_home` runs a probe-supported contact Z-home operation. `contact_auto_calibrate` runs a probe-supported contact model calibration, such as Beacon Contact autocalibration. Cartographer Survey Touch does not run `CARTOGRAPHER_TOUCH_CALIBRATE` during normal start print; that remains a user-initiated setup operation.
+
+contact_z_home fails closed when the active probe profile does not support hook-based contact Z-home. contact_auto_calibrate warns and no-ops by default when unsupported, or raises when this policy is set to `error`:
+
+```ini
+variable_probe_unsupported_contact_action_policy: "error"
+```
+
+## Developer Notes
+
+To add a new virtual-Z contact probe, create a concrete profile in `config/hardware/probes/`. Set capability variables and include a hook file only when the probe needs product-specific commands.
+
+Valid operation modes:
+
+- `none`
+- `standard_g28`
+- `hook`
+
+Hook macros receive `SOURCE`, which is one of `homing`, `start_print`, or `manual`.
+
+`standard_g28` is for Z-home dispatch. Auto-calibration support should use `hook` or `none`.

--- a/macros/base/homing/homing_override.cfg
+++ b/macros/base/homing/homing_override.cfg
@@ -22,9 +22,6 @@ gcode:
 
     {% set x_position_endstop = printer["configfile"].config["stepper_x"]["position_endstop"]|float %}
     {% set y_position_endstop = printer["configfile"].config["stepper_y"]["position_endstop"]|float %}
-    {% set x_position_center = printer.toolhead.axis_maximum.x|int/2 - printer.toolhead.axis_minimum.x|int/2 %}
-    {% set y_position_center = printer.toolhead.axis_maximum.y|int/2 - printer.toolhead.axis_minimum.y|int/2 %}
-
 
     {% if probe_type_enabled == "dockable" or probe_type_enabled == "dockable_virtual" %}
         _CHECK_PROBE action=query
@@ -295,43 +292,41 @@ gcode:
             { action_respond_info("Homing Z") }
         {% endif %}
 
-        # If there is a virtual probe endstop (ie. TAP or inductive as virtual), we go to the center of the bed
-        # If the Z endstop is not virtual, then we just move to it
-        {% if printer["configfile"].config["stepper_z"]["endstop_pin"]|lower == "probe:z_virtual_endstop" %}
-            # If our virtual endstop is a dockable probe, we need to activate it first
-            # If it's the voron tap, we put it to a safe temperature
-            {% if probe_type_enabled == "dockable_virtual" or probe_type_enabled == "vorontap" %}
-                ACTIVATE_PROBE
-            {% endif %}
-
-            # If there is a bed_mesh enabled and a zero_reference_position set, we retrieve it to home on it
-            # Else, we default to the center of the bed
-            {% if not bed_mesh_enabled or not printer["configfile"].config["bed_mesh"]["zero_reference_position"] %}
-                G0 X{x_position_center} Y{y_position_center} F{homing_travel_speed}
-            {% else %}
-                {% set ZRPx, ZRPy = printer["configfile"].config["bed_mesh"]["zero_reference_position"].split(',')|map('trim')|map('float') %}
-                G0 X{ZRPx} Y{ZRPy} F{homing_travel_speed}
-            {% endif %}
-
-        # Else, go to the Z endstop physical pin
+        {% set z_virtual = printer["configfile"].config["stepper_z"]["endstop_pin"]|lower == "probe:z_virtual_endstop" %}
+        {% set z_home_mode = printer["gcode_macro _USER_VARIABLES"].probe_contact_z_home_mode|default("none")|string|lower %}
+        {% if z_home_mode == "hook" %}
+            _PROBE_HOME_Z SOURCE=homing HOMING_TRAVEL_SPEED={homing_travel_speed} HOMING_ZHOP={homing_zhop} Z_DROP_SPEED={z_drop_speed} Z_VIRTUAL={z_virtual} BED_MESH_ENABLED={bed_mesh_enabled}
         {% else %}
-            _GOTO_Z_PROBE
-        {% endif %}
+            {% if z_virtual %}
+                {% if probe_type_enabled == "dockable_virtual" or z_home_mode == "standard_g28" %}
+                    ACTIVATE_PROBE SOURCE=homing
+                {% endif %}
 
-        G28 Z0
+                {% if bed_mesh_enabled and printer["configfile"].config["bed_mesh"] is defined and printer["configfile"].config["bed_mesh"]["zero_reference_position"] %}
+                    {% set ZRPx, ZRPy = printer["configfile"].config["bed_mesh"]["zero_reference_position"].split(',')|map('trim')|map('float') %}
+                    G0 X{ZRPx} Y{ZRPy} F{homing_travel_speed}
+                {% else %}
+                    {% set x_position_center = (printer.toolhead.axis_minimum.x|float + printer.toolhead.axis_maximum.x|float) / 2 %}
+                    {% set y_position_center = (printer.toolhead.axis_minimum.y|float + printer.toolhead.axis_maximum.y|float) / 2 %}
+                    G0 X{x_position_center} Y{y_position_center} F{homing_travel_speed}
+                {% endif %}
+            {% else %}
+                _GOTO_Z_PROBE
+            {% endif %}
 
-        G91
-        {% if printer["configfile"].settings["stepper_z"]["homing_positive_dir"] == False %}
-            G0 Z{homing_zhop} F{z_drop_speed} # small Z hop to avoid grinding the bed (as we should be close to Z0 right now)
-        {% elif printer["configfile"].settings["stepper_z"]["homing_positive_dir"] == True %}
-            G0 Z-{homing_zhop} F{z_drop_speed} # small Z move in the opposite direction to avoid staying on the endstop (not dangerous since we should be at Z max)
-        {% endif %}
-        G90
+            G28 Z0
 
-        # if voron tap, restore original temperature
-        # if dockable probe as virtual endstop, then dock the probe
-        {% if probe_type_enabled == "vorontap" or probe_type_enabled == "dockable_virtual" %}
-            DEACTIVATE_PROBE
+            G91
+            {% if printer["configfile"].settings["stepper_z"]["homing_positive_dir"] == False %}
+                G0 Z{homing_zhop} F{z_drop_speed}
+            {% elif printer["configfile"].settings["stepper_z"]["homing_positive_dir"] == True %}
+                G0 Z-{homing_zhop} F{z_drop_speed}
+            {% endif %}
+            G90
+
+            {% if probe_type_enabled == "dockable_virtual" or z_home_mode == "standard_g28" %}
+                DEACTIVATE_PROBE SOURCE=homing
+            {% endif %}
         {% endif %}
     {% endif %}
 

--- a/macros/base/probing/generic_probe.cfg
+++ b/macros/base/probing/generic_probe.cfg
@@ -4,11 +4,14 @@
 #  - Dockable probe: need to be attached/docked when used
 #  - ... can be improved depending of new probes needs ...
 
+[include virtual_z_probe.cfg]
+
 [gcode_macro ACTIVATE_PROBE]
 description: Put the machine in a state being able to probe
 variable_temperature: 0
 gcode:
     {% set LOCK = params.LOCK|default(False, boolean=true) %}
+    {% set source = params.SOURCE|default("manual")|string|lower %}
 
     {% set probe_type_enabled = printer["gcode_macro _USER_VARIABLES"].probe_type_enabled %}
 
@@ -21,32 +24,12 @@ gcode:
             _ATTACH_PROBE
         {% endif %}
 
-    # If a Voron TAP/Beacon Contact probe is defined, then check the temperature and lower it if needed
-    {% elif probe_type_enabled == "vorontap" or probe_type_enabled == "beacon_contact" %}
-        SAVE_GCODE_STATE NAME=BEFORE_TAP_ACTION
-
-        {% if probe_type_enabled == "vorontap" %}
-            {% set max_probing_temp = printer["gcode_macro _USER_VARIABLES"].tap_max_probing_temp|float %}
-        {% elif probe_type_enabled == "beacon_contact" %}
-            {% set max_probing_temp = printer["gcode_macro _USER_VARIABLES"].beacon_max_probing_temp|float %}
-        {% endif %}
-
-        {% set ACTUAL_TEMP = printer.extruder.temperature %}
-        {% set TARGET_TEMP = printer.extruder.target %}
-
-        SET_GCODE_VARIABLE MACRO=ACTIVATE_PROBE VARIABLE=temperature VALUE={TARGET_TEMP}
-
-        {% if TARGET_TEMP > max_probing_temp %}
-            { action_respond_info('Extruder temperature target of %.1fC is too high for TAP probing, lowering to %.1fC' % (TARGET_TEMP, max_probing_temp)) }
-            M106 S255 ; 100% the part cooling fan to help the extruder cooling
-            M109 S{max_probing_temp}
-            M106 S0   ; Stop the part cooling fan
-        {% else %}
-            # Temperature target is already low enough, but nozzle may still be too hot
-            {% if ACTUAL_TEMP > max_probing_temp + 3 %}
-                M106 S255 ; 100% the part cooling fan to help the extruder cooling
-                TEMPERATURE_WAIT SENSOR=extruder MAXIMUM={max_probing_temp}
-                M106 S0   ; Stop the part cooling fan
+    # If a contact probe needs a temperature guard, route lifecycle through the framework
+    {% elif printer["gcode_macro _USER_VARIABLES"].probe_needs_contact_temp_guard|default(False) %}
+        {% if not printer["gcode_macro _PROBE_FRAMEWORK_STATE"].active %}
+            _PROBE_ENTER_CONTACT_GUARD OPERATION=activate_probe SOURCE={source}
+            {% if "_PROBE_HOOK_CONTACT_ACTIVATE" in printer.gcode.commands %}
+                _PROBE_HOOK_CONTACT_ACTIVATE SOURCE={source}
             {% endif %}
         {% endif %}
     {% endif %}
@@ -56,6 +39,7 @@ gcode:
 description: Revert the machine to a normal state after probing
 gcode:
     {% set UNLOCK = params.UNLOCK|default(False, boolean=true) %}
+    {% set source = params.SOURCE|default("manual")|string|lower %}
 
     {% set probe_type_enabled = printer["gcode_macro _USER_VARIABLES"].probe_type_enabled %}
     {% set Sz = printer["gcode_macro _USER_VARIABLES"].z_drop_speed * 60 %}
@@ -69,25 +53,12 @@ gcode:
             _DOCK_PROBE
         {% endif %}
 
-    # If a Voron TAP/Beacon Contact probe is defined, then check and restore the nozzle temperature if needed
-    {% elif probe_type_enabled == "vorontap" or probe_type_enabled == "beacon_contact" %}
-        {% if probe_type_enabled == "vorontap" %}
-            {% set deactivation_zhop = printer["gcode_macro _USER_VARIABLES"].tap_deactivation_zhop %}
-        {% elif probe_type_enabled == "beacon_contact" %}
-            {% set deactivation_zhop = printer["gcode_macro _USER_VARIABLES"].beacon_deactivation_zhop %}
+    # If a contact probe needs a temperature guard, route lifecycle through the framework
+    {% elif printer["gcode_macro _USER_VARIABLES"].probe_needs_contact_temp_guard|default(False) %}
+        {% if printer["gcode_macro _PROBE_FRAMEWORK_STATE"].active %}
+            {% if "_PROBE_HOOK_CONTACT_DEACTIVATE" in printer.gcode.commands %}
+                _PROBE_HOOK_CONTACT_DEACTIVATE SOURCE={source}
+            {% endif %}
+            _PROBE_EXIT_CONTACT_GUARD
         {% endif %}
-
-        # Small Z hop to avoid restoring the temperature directly on the PEI
-        {% set z_safe = printer.toolhead.position.z + deactivation_zhop %}
-        {% if z_safe > printer.toolhead.axis_maximum.z %}
-            {% set z_safe = printer.toolhead.axis_maximum.z %}
-        {% endif %}
-        G90
-        G1 Z{z_safe} F{Sz}
-
-        # Then restoring the temperature
-        {% set old_target_temperature = printer["gcode_macro ACTIVATE_PROBE"].temperature %}
-        M109 S{old_target_temperature}
-
-        RESTORE_GCODE_STATE NAME=BEFORE_TAP_ACTION
     {% endif %}

--- a/macros/base/probing/hooks/beacon_contact.cfg
+++ b/macros/base/probing/hooks/beacon_contact.cfg
@@ -1,0 +1,25 @@
+[gcode_macro _PROBE_HOOK_CONTACT_Z_HOME]
+description: Beacon Contact Z homing hook
+gcode:
+    {% set source = params.SOURCE|default("manual")|string|lower %}
+    _PROBE_VALIDATE_SOURCE SOURCE={source}
+    G28 Z METHOD=CONTACT CALIBRATE=0
+
+[gcode_macro _PROBE_HOOK_CONTACT_AUTO_CALIBRATE]
+description: Beacon Contact automatic model calibration hook
+gcode:
+    {% set source = params.SOURCE|default("manual")|string|lower %}
+    _PROBE_VALIDATE_SOURCE SOURCE={source}
+    G28 Z METHOD=CONTACT CALIBRATE=1
+
+[gcode_macro _PROBE_HOOK_CONTACT_ACTIVATE]
+description: Beacon Contact activation hook
+gcode:
+    {% set source = params.SOURCE|default("manual")|string|lower %}
+    _PROBE_VALIDATE_SOURCE SOURCE={source}
+
+[gcode_macro _PROBE_HOOK_CONTACT_DEACTIVATE]
+description: Beacon Contact deactivation hook
+gcode:
+    {% set source = params.SOURCE|default("manual")|string|lower %}
+    _PROBE_VALIDATE_SOURCE SOURCE={source}

--- a/macros/base/probing/hooks/cartographer_touch.cfg
+++ b/macros/base/probing/hooks/cartographer_touch.cfg
@@ -1,0 +1,18 @@
+[gcode_macro _PROBE_HOOK_CONTACT_Z_HOME]
+description: Cartographer Touch Z homing hook
+gcode:
+    {% set source = params.SOURCE|default("manual")|string|lower %}
+    _PROBE_VALIDATE_SOURCE SOURCE={source}
+    CARTOGRAPHER_TOUCH_HOME
+
+[gcode_macro _PROBE_HOOK_CONTACT_ACTIVATE]
+description: Cartographer Touch activation hook
+gcode:
+    {% set source = params.SOURCE|default("manual")|string|lower %}
+    _PROBE_VALIDATE_SOURCE SOURCE={source}
+
+[gcode_macro _PROBE_HOOK_CONTACT_DEACTIVATE]
+description: Cartographer Touch deactivation hook
+gcode:
+    {% set source = params.SOURCE|default("manual")|string|lower %}
+    _PROBE_VALIDATE_SOURCE SOURCE={source}

--- a/macros/base/probing/virtual_z_probe.cfg
+++ b/macros/base/probing/virtual_z_probe.cfg
@@ -1,0 +1,238 @@
+[gcode_macro _PROBE_FRAMEWORK_STATE]
+description: Internal state for shared virtual-Z probe framework operations
+variable_active: False
+variable_saved_temperature: 0
+variable_operation: ""
+variable_source: ""
+gcode:
+
+
+[gcode_macro _PROBE_VALIDATE_SOURCE]
+description: Validate a virtual-Z probe framework source
+gcode:
+    {% set source = params.SOURCE|default("manual")|lower %}
+    {% if source not in ["homing", "start_print", "manual"] %}
+        { action_raise_error("Invalid probe framework SOURCE '%s'. Expected one of: homing, start_print, manual" % source) }
+    {% endif %}
+
+
+[gcode_macro _PROBE_RESOLVE_CONTACT_MAX_TEMP]
+description: Report the resolved contact probing maximum temperature
+gcode:
+    {% set vars = printer["gcode_macro _USER_VARIABLES"] %}
+    {% set probe_type_enabled = vars.probe_type_enabled|string %}
+
+    {% if vars.probe_contact_max_temp is defined %}
+        {% set max_probing_temp = vars.probe_contact_max_temp|float %}
+    {% elif probe_type_enabled == "vorontap" and vars.tap_max_probing_temp is defined %}
+        {% set max_probing_temp = vars.tap_max_probing_temp|float %}
+    {% elif probe_type_enabled == "beacon_contact" and vars.beacon_max_probing_temp is defined %}
+        {% set max_probing_temp = vars.beacon_max_probing_temp|float %}
+    {% else %}
+        {% set max_probing_temp = 150.0 %}
+    {% endif %}
+
+    RESPOND MSG="Resolved contact probing max temperature: {max_probing_temp}"
+
+
+[gcode_macro _PROBE_ENTER_CONTACT_GUARD]
+description: Enter guarded contact-probe operation temperature handling
+gcode:
+    {% set vars = printer["gcode_macro _USER_VARIABLES"] %}
+    {% set state = printer["gcode_macro _PROBE_FRAMEWORK_STATE"] %}
+    {% set source = params.SOURCE|default("manual")|lower %}
+    {% set operation = params.OPERATION|default("")|string %}
+    {% set probe_type_enabled = vars.probe_type_enabled|string %}
+
+    {% if source not in ["homing", "start_print", "manual"] %}
+        { action_raise_error("Invalid probe framework SOURCE '%s'. Expected one of: homing, start_print, manual" % source) }
+    {% endif %}
+
+    {% if state.active %}
+        { action_raise_error("Contact probe guard is already active for operation '%s' from SOURCE '%s'" % (state.operation, state.source)) }
+    {% endif %}
+
+    {% if vars.probe_contact_max_temp is defined %}
+        {% set max_probing_temp = vars.probe_contact_max_temp|float %}
+    {% elif probe_type_enabled == "vorontap" and vars.tap_max_probing_temp is defined %}
+        {% set max_probing_temp = vars.tap_max_probing_temp|float %}
+    {% elif probe_type_enabled == "beacon_contact" and vars.beacon_max_probing_temp is defined %}
+        {% set max_probing_temp = vars.beacon_max_probing_temp|float %}
+    {% else %}
+        {% set max_probing_temp = 150.0 %}
+    {% endif %}
+
+    {% set actual_temperature = printer.extruder.temperature|float %}
+    {% set target_temperature = printer.extruder.target|float %}
+
+    SAVE_GCODE_STATE NAME=BEFORE_PROBE_CONTACT_GUARD
+    SET_GCODE_VARIABLE MACRO=_PROBE_FRAMEWORK_STATE VARIABLE=active VALUE={ True }
+    SET_GCODE_VARIABLE MACRO=_PROBE_FRAMEWORK_STATE VARIABLE=saved_temperature VALUE={ target_temperature }
+    SET_GCODE_VARIABLE MACRO=_PROBE_FRAMEWORK_STATE VARIABLE=operation VALUE='"{operation}"'
+    SET_GCODE_VARIABLE MACRO=_PROBE_FRAMEWORK_STATE VARIABLE=source VALUE='"{source}"'
+
+    {% if target_temperature > max_probing_temp %}
+        M106 S255
+        M109 S{max_probing_temp}
+        M106 S0
+    {% elif actual_temperature > max_probing_temp + 3 %}
+        M106 S255
+        TEMPERATURE_WAIT SENSOR=extruder MAXIMUM={max_probing_temp}
+        M106 S0
+    {% endif %}
+
+
+[gcode_macro _PROBE_EXIT_CONTACT_GUARD]
+description: Exit guarded contact-probe operation temperature handling
+gcode:
+    {% set vars = printer["gcode_macro _USER_VARIABLES"] %}
+    {% set state = printer["gcode_macro _PROBE_FRAMEWORK_STATE"] %}
+    {% set probe_type_enabled = vars.probe_type_enabled|string %}
+
+    {% if state.active %}
+        {% if vars.probe_contact_deactivation_zhop is defined %}
+            {% set deactivation_zhop = vars.probe_contact_deactivation_zhop|float %}
+        {% elif probe_type_enabled == "vorontap" and vars.tap_deactivation_zhop is defined %}
+            {% set deactivation_zhop = vars.tap_deactivation_zhop|float %}
+        {% elif probe_type_enabled == "beacon_contact" and vars.beacon_deactivation_zhop is defined %}
+            {% set deactivation_zhop = vars.beacon_deactivation_zhop|float %}
+        {% else %}
+            {% set deactivation_zhop = 5.0 %}
+        {% endif %}
+
+        {% if 'z' in printer.toolhead.homed_axes and deactivation_zhop > 0 %}
+            {% set z_safe = printer.toolhead.position.z|float + deactivation_zhop %}
+            {% if z_safe > printer.toolhead.axis_maximum.z|float %}
+                {% set z_safe = printer.toolhead.axis_maximum.z|float %}
+            {% endif %}
+            G90
+            G1 Z{z_safe} F{vars.z_drop_speed|float * 60}
+        {% endif %}
+
+        M109 S{state.saved_temperature}
+        RESTORE_GCODE_STATE NAME=BEFORE_PROBE_CONTACT_GUARD
+        SET_GCODE_VARIABLE MACRO=_PROBE_FRAMEWORK_STATE VARIABLE=active VALUE={ False }
+        SET_GCODE_VARIABLE MACRO=_PROBE_FRAMEWORK_STATE VARIABLE=saved_temperature VALUE={ 0 }
+        SET_GCODE_VARIABLE MACRO=_PROBE_FRAMEWORK_STATE VARIABLE=operation VALUE='""'
+        SET_GCODE_VARIABLE MACRO=_PROBE_FRAMEWORK_STATE VARIABLE=source VALUE='""'
+    {% endif %}
+
+
+[gcode_macro _PROBE_RECOVER_CONTACT_GUARD]
+description: Recover a failed guarded contact-probe operation
+gcode:
+    {% set state = printer["gcode_macro _PROBE_FRAMEWORK_STATE"] %}
+    {% set confirm = params.CONFIRM|default(0)|int %}
+
+    {% if state.active %}
+        {% if confirm != 1 %}
+            RESPOND MSG="Contact probe guard is active with saved target {state.saved_temperature}C. Move the nozzle to a safe position, then rerun _PROBE_RECOVER_CONTACT_GUARD CONFIRM=1 to restore the target."
+        {% else %}
+            M104 S{state.saved_temperature}
+            SET_GCODE_VARIABLE MACRO=_PROBE_FRAMEWORK_STATE VARIABLE=active VALUE={ False }
+            SET_GCODE_VARIABLE MACRO=_PROBE_FRAMEWORK_STATE VARIABLE=saved_temperature VALUE={ 0 }
+            SET_GCODE_VARIABLE MACRO=_PROBE_FRAMEWORK_STATE VARIABLE=operation VALUE='""'
+            SET_GCODE_VARIABLE MACRO=_PROBE_FRAMEWORK_STATE VARIABLE=source VALUE='""'
+        {% endif %}
+    {% endif %}
+
+
+[gcode_macro _PROBE_CONTACT_Z_HOME]
+description: Run contact-probe Z homing through the configured hook
+gcode:
+    {% set vars = printer["gcode_macro _USER_VARIABLES"] %}
+    {% set source = params.SOURCE|default("manual")|lower %}
+    {% set mode = vars.probe_contact_z_home_mode|default("none")|lower %}
+
+    {% if source not in ["homing", "start_print", "manual"] %}
+        { action_raise_error("Invalid probe framework SOURCE '%s'. Expected one of: homing, start_print, manual" % source) }
+    {% endif %}
+
+    {% if mode != "hook" %}
+        { action_raise_error("Contact Z home requires probe_contact_z_home_mode to be 'hook'") }
+    {% endif %}
+
+    _PROBE_ENTER_CONTACT_GUARD OPERATION=contact_z_home SOURCE={source}
+    _PROBE_HOOK_CONTACT_Z_HOME SOURCE={source}
+    _PROBE_EXIT_CONTACT_GUARD
+
+
+[gcode_macro _PROBE_CONTACT_AUTO_CALIBRATE]
+description: Run contact-probe auto-calibration through the configured hook
+gcode:
+    {% set vars = printer["gcode_macro _USER_VARIABLES"] %}
+    {% set source = params.SOURCE|default("manual")|lower %}
+    {% set mode = vars.probe_contact_auto_calibrate_mode|default("none")|lower %}
+    {% set policy = vars.probe_unsupported_contact_action_policy|default("warn")|lower %}
+    {% set probe_type_enabled = vars.probe_type_enabled|string %}
+
+    {% if source not in ["homing", "start_print", "manual"] %}
+        { action_raise_error("Invalid probe framework SOURCE '%s'. Expected one of: homing, start_print, manual" % source) }
+    {% endif %}
+
+    {% if policy not in ["warn", "error"] %}
+        { action_raise_error("Invalid probe_unsupported_contact_action_policy '%s'. Expected one of: warn, error" % policy) }
+    {% endif %}
+
+    {% if mode == "hook" %}
+        _PROBE_ENTER_CONTACT_GUARD OPERATION=contact_auto_calibrate SOURCE={source}
+        _PROBE_HOOK_CONTACT_AUTO_CALIBRATE SOURCE={source}
+        _PROBE_EXIT_CONTACT_GUARD
+    {% elif policy == "error" %}
+        { action_raise_error("Contact auto-calibrate is not supported for probe_type_enabled '%s'" % probe_type_enabled) }
+    {% elif policy == "warn" %}
+        RESPOND MSG="Skipping contact auto-calibrate for probe_type_enabled {probe_type_enabled}"
+    {% endif %}
+
+
+[gcode_macro _PROBE_HOME_Z]
+description: Run hook-mode virtual-Z probe homing
+gcode:
+    {% set vars = printer["gcode_macro _USER_VARIABLES"] %}
+    {% set source = params.SOURCE|default("manual")|lower %}
+    {% set mode = vars.probe_contact_z_home_mode|default("none")|lower %}
+    {% set homing_travel_speed = params.HOMING_TRAVEL_SPEED|default(vars.homing_travel_speed|float * 60)|float %}
+    {% set homing_zhop = params.HOMING_ZHOP|default(vars.homing_zhop|float|abs)|float|abs %}
+    {% set z_drop_speed = params.Z_DROP_SPEED|default(vars.z_drop_speed|float * 60)|float %}
+    {% set configured_z_virtual = printer["configfile"].config["stepper_z"]["endstop_pin"]|lower == "probe:z_virtual_endstop" %}
+    {% if params.Z_VIRTUAL is defined %}
+        {% set z_virtual = params.Z_VIRTUAL|string|lower in ["true", "1", "yes", "on"] %}
+    {% else %}
+        {% set z_virtual = configured_z_virtual %}
+    {% endif %}
+    {% if params.BED_MESH_ENABLED is defined %}
+        {% set bed_mesh_enabled = params.BED_MESH_ENABLED|string|lower in ["true", "1", "yes", "on"] %}
+    {% else %}
+        {% set bed_mesh_enabled = False %}
+    {% endif %}
+
+    {% if source not in ["homing", "start_print", "manual"] %}
+        { action_raise_error("Invalid probe framework SOURCE '%s'. Expected one of: homing, start_print, manual" % source) }
+    {% endif %}
+
+    {% if mode != "hook" %}
+        { action_raise_error("_PROBE_HOME_Z is only for hook-mode contact probes. Use G28 Z for probe_contact_z_home_mode '%s'." % mode) }
+    {% endif %}
+
+    {% if z_virtual %}
+        {% if bed_mesh_enabled and printer["configfile"].config["bed_mesh"] is defined and printer["configfile"].config["bed_mesh"]["zero_reference_position"] %}
+            {% set ZRPx, ZRPy = printer["configfile"].config["bed_mesh"]["zero_reference_position"].split(',')|map('trim')|map('float') %}
+            G0 X{ZRPx} Y{ZRPy} F{homing_travel_speed}
+        {% else %}
+            {% set x_position_center = (printer.toolhead.axis_minimum.x|float + printer.toolhead.axis_maximum.x|float) / 2 %}
+            {% set y_position_center = (printer.toolhead.axis_minimum.y|float + printer.toolhead.axis_maximum.y|float) / 2 %}
+            G0 X{x_position_center} Y{y_position_center} F{homing_travel_speed}
+        {% endif %}
+    {% else %}
+        _GOTO_Z_PROBE
+    {% endif %}
+
+    _PROBE_CONTACT_Z_HOME SOURCE={source}
+
+    G91
+    {% if printer["configfile"].settings["stepper_z"]["homing_positive_dir"] == False %}
+        G0 Z{homing_zhop} F{z_drop_speed}
+    {% elif printer["configfile"].settings["stepper_z"]["homing_positive_dir"] == True %}
+        G0 Z-{homing_zhop} F{z_drop_speed}
+    {% endif %}
+    G90

--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -166,8 +166,12 @@ gcode:
             _MODULE_CLEAN
         {% elif action == "z_offset" %}
             _MODULE_Z_CALIB
+        {% elif action == "contact_z_home" %}
+            _MODULE_CONTACT_Z_HOME
+        {% elif action == "contact_auto_calibrate" %}
+            _MODULE_CONTACT_AUTO_CALIBRATE
         {% elif action == "beacon_calib" %}
-            _MODULE_BEACON_CALIB
+            _MODULE_CONTACT_AUTO_CALIBRATE
         {% elif action == "bedmesh" %}
             _MODULE_BED_MESH
         {% elif action == "primeline" %}
@@ -433,22 +437,28 @@ gcode:
     {% if zcalib_plugin_enabled %}
         G28 Z
         CALIBRATE_Z
-    {% elif probe_type_enabled == "beacon contact" %}
-        G28 Z METHOD=CONTACT CALIBRATE=0
+    {% elif probe_type_enabled == "beacon_contact" %}
+        _PROBE_CONTACT_Z_HOME SOURCE=start_print
     {% else %}
         G28 Z
     {% endif %}
 
 
-[gcode_macro _MODULE_BEACON_CALIB]
+[gcode_macro _MODULE_CONTACT_Z_HOME]
 gcode:
-    # ----- BEACON CALIBRATION --------------------------------
-    # If Beacon contact is enabled this will autocalibrate the model
-    {% set probe_type_enabled = printer["gcode_macro _USER_VARIABLES"].probe_type_enabled %}
-
-    {% if probe_type_enabled == "beacon_contact" %}
-        G28 Z METHOD=CONTACT CALIBRATE=1
+    {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
+    {% if verbose %}
+        RESPOND MSG="Contact Z home"
     {% endif %}
+    _PROBE_CONTACT_Z_HOME SOURCE=start_print
+
+[gcode_macro _MODULE_CONTACT_AUTO_CALIBRATE]
+gcode:
+    {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
+    {% if verbose %}
+        RESPOND MSG="Contact auto-calibration"
+    {% endif %}
+    _PROBE_CONTACT_AUTO_CALIBRATE SOURCE=start_print
 
 [gcode_macro _MODULE_BED_MESH]
 gcode:
@@ -480,7 +490,6 @@ gcode:
     # Preheat the nozzle to safe probing temperature.
     {% set safe_extruder_temp = printer["gcode_macro _USER_VARIABLES"].safe_extruder_temp|float %}
     {% set status_leds_control_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_control_enabled|default(False) %}
-    {% set probe_type_enabled = printer["gcode_macro _USER_VARIABLES"].probe_type_enabled %}
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
 
     {% if status_leds_control_enabled %}
@@ -490,7 +499,7 @@ gcode:
         RESPOND MSG="Pre-heating the nozzle to a safe temperature..."
     {% endif %}
 
-    {% if probe_type_enabled == "vorontap" or probe_type_enabled == "beacon_contact" %}
+    {% if printer["gcode_macro _USER_VARIABLES"].probe_needs_contact_temp_guard|default(False) %}
         M109 S{safe_extruder_temp}
         {% if verbose %}
             RESPOND MSG="Extruder at safe temperature of {safe_extruder_temp} degrees"

--- a/macros/miscs/startup.cfg
+++ b/macros/miscs/startup.cfg
@@ -82,6 +82,8 @@ gcode:
     {% set qgl_enabled = printer["gcode_macro _USER_VARIABLES"].qgl_enabled %}
     {% set ztilt_enabled = printer["gcode_macro _USER_VARIABLES"].ztilt_enabled %}
 
+    _INIT_CHECK_VIRTUAL_Z_PROBE
+
     # Check the Beacon firmware version for contact probing
     {% if probe_type_enabled == "beacon_contact" %}
         {% if 'mcu beacon' in printer %}
@@ -127,6 +129,58 @@ gcode:
 
     {% if ztilt_enabled and probe_type_enabled == "none" %}
         { action_raise_error("You need a to define a probe to be able to perform a Z tilt adjust in Klippain!") }
+    {% endif %}
+
+
+[gcode_macro _INIT_CHECK_VIRTUAL_Z_PROBE]
+gcode:
+    {% set vars = printer["gcode_macro _USER_VARIABLES"] %}
+    {% set verbose = vars.verbose|default(False) %}
+    {% set probe_type = vars.probe_type_enabled|string %}
+    {% set valid_modes = ["none", "standard_g28", "hook"] %}
+    {% set z_home_mode = vars.probe_contact_z_home_mode|default("none")|string %}
+    {% set auto_cal_mode = vars.probe_contact_auto_calibrate_mode|default("none")|string %}
+    {% set hook_family = vars.probe_hook_family|default("")|string %}
+    {% set hook_family_allowed_chars = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-" %}
+    {% set invalid_hook_family = namespace(found=False) %}
+    {% set needs_contact_guard = vars.probe_needs_contact_temp_guard|default(False) %}
+
+    {% if z_home_mode not in valid_modes %}
+        { action_raise_error("Invalid probe_contact_z_home_mode '%s' for probe '%s'. Valid values are: none, standard_g28, hook" % (z_home_mode, probe_type)) }
+    {% endif %}
+    {% if auto_cal_mode not in valid_modes %}
+        { action_raise_error("Invalid probe_contact_auto_calibrate_mode '%s' for probe '%s'. Valid values are: none, standard_g28, hook" % (auto_cal_mode, probe_type)) }
+    {% endif %}
+    {% for char in hook_family %}
+        {% if char not in hook_family_allowed_chars %}
+            {% set invalid_hook_family.found = True %}
+        {% endif %}
+    {% endfor %}
+    {% if invalid_hook_family.found %}
+        { action_raise_error("Invalid probe_hook_family '%s' for probe '%s'. Use an empty value or a simple slug with only letters, digits, underscore, and hyphen, such as beacon_contact" % (hook_family, probe_type)) }
+    {% endif %}
+    {% if hook_family and z_home_mode == "none" and auto_cal_mode == "none" %}
+        { action_raise_error("Probe '%s' sets probe_hook_family='%s' but all contact operation modes are none" % (probe_type, hook_family)) }
+    {% endif %}
+    {% if z_home_mode == "hook" and "_PROBE_HOOK_CONTACT_Z_HOME" not in printer.gcode.commands %}
+        { action_raise_error("Probe '%s' uses hook contact Z home but _PROBE_HOOK_CONTACT_Z_HOME is missing" % probe_type) }
+    {% endif %}
+    {% if auto_cal_mode == "hook" and "_PROBE_HOOK_CONTACT_AUTO_CALIBRATE" not in printer.gcode.commands %}
+        { action_raise_error("Probe '%s' uses hook contact auto-calibrate but _PROBE_HOOK_CONTACT_AUTO_CALIBRATE is missing" % probe_type) }
+    {% endif %}
+    {% if hook_family and needs_contact_guard and "_PROBE_HOOK_CONTACT_ACTIVATE" not in printer.gcode.commands %}
+        { action_raise_error("Probe '%s' uses hook family '%s' with contact guard but _PROBE_HOOK_CONTACT_ACTIVATE is missing" % (probe_type, hook_family)) }
+    {% endif %}
+    {% if hook_family and needs_contact_guard and "_PROBE_HOOK_CONTACT_DEACTIVATE" not in printer.gcode.commands %}
+        { action_raise_error("Probe '%s' uses hook family '%s' with contact guard but _PROBE_HOOK_CONTACT_DEACTIVATE is missing" % (probe_type, hook_family)) }
+    {% endif %}
+
+    {% if vars.probe_contact_max_temp is defined %}
+        {% if probe_type == "vorontap" and vars.tap_max_probing_temp is defined and vars.probe_contact_max_temp|float != vars.tap_max_probing_temp|float and verbose %}
+            RESPOND MSG="probe_contact_max_temp overrides tap_max_probing_temp for Voron TAP"
+        {% elif probe_type == "beacon_contact" and vars.beacon_max_probing_temp is defined and vars.probe_contact_max_temp|float != vars.beacon_max_probing_temp|float and verbose %}
+            RESPOND MSG="probe_contact_max_temp overrides beacon_max_probing_temp for Beacon Contact"
+        {% endif %}
     {% endif %}
 
 

--- a/scripts/validate_probe_framework.py
+++ b/scripts/validate_probe_framework.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import ast
+import re
+import sys
+from pathlib import Path
+
+
+VALID_MODES = {"none", "standard_g28", "hook"}
+HOOK_MACROS = {
+    "contact_z_home": "_PROBE_HOOK_CONTACT_Z_HOME",
+    "contact_auto_calibrate": "_PROBE_HOOK_CONTACT_AUTO_CALIBRATE",
+    "contact_activate": "_PROBE_HOOK_CONTACT_ACTIVATE",
+    "contact_deactivate": "_PROBE_HOOK_CONTACT_DEACTIVATE",
+}
+BANNED_NAMES = {"cartographer_survey.cfg"}
+REQUIRED_REPO_PATHS = {
+    "README.md": "file",
+    "config/machine.cfg": "file",
+    "config/hardware/probes": "dir",
+    "macros/base/probing": "dir",
+    "scripts": "dir",
+}
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def variable(text: str, name: str, default: str = "") -> str:
+    match = re.search(rf"^\s*variable_{re.escape(name)}\s*:\s*(.*?)\s*$", text, re.M)
+    if not match:
+        return default
+    value = strip_inline_comment(match.group(1)).strip()
+    try:
+        return str(ast.literal_eval(value))
+    except (SyntaxError, ValueError):
+        return value
+
+
+def strip_inline_comment(value: str) -> str:
+    in_single_quote = False
+    in_double_quote = False
+    for index, char in enumerate(value):
+        if char == "'" and not in_double_quote:
+            in_single_quote = not in_single_quote
+        elif char == '"' and not in_single_quote:
+            in_double_quote = not in_double_quote
+        elif char == "#" and not in_single_quote and not in_double_quote:
+            return value[:index].strip()
+    return value.strip()
+
+
+def includes_hook(text: str, hook_family: str) -> bool:
+    if not hook_family:
+        return False
+    return hook_family in hook_includes(text)
+
+
+def hook_includes(text: str) -> list[str]:
+    return re.findall(r"^\s*\[include\s+[^\]]*hooks/([A-Za-z0-9_-]+)\.cfg\s*\]\s*(?:#.*)?$", text, re.M)
+
+
+def has_macro(text: str, macro: str) -> bool:
+    return re.search(rf"^\s*\[gcode_macro\s+{re.escape(macro)}\]\s*(?:#.*)?$", text, re.M) is not None
+
+
+def validate_repo_layout(repo: Path) -> list[str]:
+    errors: list[str] = []
+    if not repo.is_dir():
+        return [f"repository root does not exist or is not a directory: {repo}"]
+
+    for relative_path, expected_type in REQUIRED_REPO_PATHS.items():
+        path = repo / relative_path
+        if expected_type == "dir" and not path.is_dir():
+            errors.append(f"required directory is missing: {path}")
+        elif expected_type == "file" and not path.is_file():
+            errors.append(f"required file is missing: {path}")
+
+    return errors
+
+
+def validate(repo: Path) -> list[str]:
+    errors = validate_repo_layout(repo)
+    if errors:
+        return errors
+
+    profiles_dir = repo / "config" / "hardware" / "probes"
+    hooks_dir = repo / "macros" / "base" / "probing" / "hooks"
+
+    for banned in BANNED_NAMES:
+        if (profiles_dir / banned).exists():
+            errors.append(f"unmerged PR compatibility alias must not exist: {profiles_dir / banned}")
+
+    for profile in sorted(profiles_dir.glob("*.cfg")):
+        text = read(profile)
+        hook_family = variable(text, "probe_hook_family")
+        needs_contact_guard = variable(text, "probe_needs_contact_temp_guard", "False").lower() == "true"
+        z_home_mode = variable(text, "probe_contact_z_home_mode", "none")
+        auto_cal_mode = variable(text, "probe_contact_auto_calibrate_mode", "none")
+        declared_hook_includes = hook_includes(text)
+
+        for mode_name, mode in {
+            "probe_contact_z_home_mode": z_home_mode,
+            "probe_contact_auto_calibrate_mode": auto_cal_mode,
+        }.items():
+            if mode not in VALID_MODES:
+                errors.append(f"{profile}: {mode_name} has invalid value {mode!r}; valid values are {sorted(VALID_MODES)}")
+
+        if hook_family and z_home_mode == "none" and auto_cal_mode == "none":
+            errors.append(f"{profile}: hook family {hook_family!r} is set but both contact operation modes are none")
+
+        if len(declared_hook_includes) > 1:
+            errors.append(f"{profile}: includes multiple hook families {declared_hook_includes}; include exactly one hook family per profile")
+
+        if hook_family and not includes_hook(text, hook_family):
+            errors.append(f"{profile}: hook family {hook_family!r} is set but hooks/{hook_family}.cfg is not included")
+
+        for included_hook in declared_hook_includes:
+            included_hook_file = hooks_dir / f"{included_hook}.cfg"
+            if not included_hook_file.exists():
+                errors.append(f"{profile}: includes hooks/{included_hook}.cfg but {included_hook_file} does not exist")
+            if hook_family != included_hook:
+                errors.append(f"{profile}: includes hooks/{included_hook}.cfg but probe_hook_family is {hook_family!r}")
+
+        hook_file = hooks_dir / f"{hook_family}.cfg" if hook_family else None
+        hook_text = read(hook_file) if hook_file and hook_file.exists() else ""
+
+        if z_home_mode == "hook":
+            if not hook_file or not hook_file.exists():
+                errors.append(f"{profile}: contact Z home uses hook mode but {hook_file} does not exist")
+            elif not has_macro(hook_text, HOOK_MACROS["contact_z_home"]):
+                errors.append(f"{profile}: contact Z home uses hook mode but {HOOK_MACROS['contact_z_home']} is missing")
+
+        if auto_cal_mode == "hook":
+            if not hook_file or not hook_file.exists():
+                errors.append(f"{profile}: contact auto-calibrate uses hook mode but {hook_file} does not exist")
+            elif not has_macro(hook_text, HOOK_MACROS["contact_auto_calibrate"]):
+                errors.append(f"{profile}: contact auto-calibrate uses hook mode but {HOOK_MACROS['contact_auto_calibrate']} is missing")
+
+        if hook_family and needs_contact_guard:
+            if not hook_file or not hook_file.exists():
+                errors.append(f"{profile}: contact guard uses hook family {hook_family!r} but {hook_file} does not exist")
+            else:
+                for lifecycle_name in ("contact_activate", "contact_deactivate"):
+                    lifecycle_macro = HOOK_MACROS[lifecycle_name]
+                    if not has_macro(hook_text, lifecycle_macro):
+                        errors.append(f"{profile}: contact guard uses hook family {hook_family!r} but {lifecycle_macro} is missing")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Validate Klippain virtual-Z probe framework contracts.")
+    parser.add_argument("--repo", type=Path, default=Path.cwd(), help="Repository root")
+    args = parser.parse_args()
+
+    errors = validate(args.repo.resolve())
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+    print("virtual-Z probe framework contracts OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/user_templates/printer.cfg
+++ b/user_templates/printer.cfg
@@ -112,6 +112,9 @@
 ## Beacon probe also used as virtual Z endstop. Do not forget to install the plugin and add the [beacon] section to make it work!
 # [include config/hardware/probes/beacon_virtual.cfg]   # Uncomment if Beacon firmware version is 1.x
 # [include config/hardware/probes/beacon_contact.cfg]   # Uncomment if Beacon firmware version is 2.x or higher
+
+## Cartographer Survey Touch probe also used as virtual Z endstop. Install the Cartographer plugin and configure the scanner MCU first.
+# [include config/hardware/probes/cartographer_touch.cfg]
 # ----------------------------------------------------------------------------------------
 
 

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -147,6 +147,17 @@ variable_autodock_on_probe_error: True
 
 
 ##########################################################
+# Virtual Z contact probe variables
+##########################################################
+
+## Preferred shared variables for nozzle/contact probes.
+## Existing tap_* and beacon_* variables remain supported as compatibility fallbacks.
+variable_probe_contact_max_temp: 150
+variable_probe_contact_deactivation_zhop: 5
+variable_probe_unsupported_contact_action_policy: "warn" # "warn" or "error"
+
+
+##########################################################
 # Voron TAP probe variables (if available in the machine)
 ##########################################################
 


### PR DESCRIPTION
Adds a generic virtual-Z contact probe framework for nozzle-based probing flows, covering TAP-style standard `G28`, Beacon Contact, and Cartographer Touch without baking probe-specific behavior into shared homing/start-print
macros.

Probe profiles now declare their contact capabilities through shared variables, including the contact homing mode, optional auto-calibration mode, and hook family. Hook-mode probes include exactly one hook file under `macros/
base/probing/hooks/`, which implements the shared hook macro names:

- `_PROBE_HOOK_CONTACT_Z_HOME`
- `_PROBE_HOOK_CONTACT_AUTO_CALIBRATE` when supported
- `_PROBE_HOOK_CONTACT_ACTIVATE`
- `_PROBE_HOOK_CONTACT_DEACTIVATE`

The shared framework handles source validation, contact temperature guarding, lifecycle state, guarded recovery, and dispatch into the selected probe hook.

## Key Changes

- Replaces hardcoded Beacon/TAP-style contact behavior with capability-driven probe profiles.
- Adds Beacon Contact and Cartographer Touch hook implementations.
- Keeps TAP on the normal `G28 Z` path while routing hook-mode probes through `_PROBE_HOME_Z`.
- Adds generic START_PRINT actions: `contact_z_home` and `contact_auto_calibrate`.
- Keeps `beacon_calib` as a compatibility alias for existing configs.
- Adds startup/static validation for hook family includes, required hook macros, supported modes, and invalid profile combinations.

## Validation

Real-printer smoke testing covered Beacon Contact and Voron TAP paths, including repeated activate/deactivate, guarded recovery, contact auto-calibration,
hook homing, and TAP `G28 Z` recursion handling.