### PR TITLE
fix: Decouple toolhead status LEDs from caselights / minidisplay

### DIFF
--- a/config/hardware/lights/neopixel_caselight.cfg
+++ b/config/hardware/lights/neopixel_caselight.cfg
@@ -1,6 +1,7 @@
 # Neopixel leds used as general printer lights
 
 [gcode_macro _USER_VARIABLES]
+variable_status_leds_control_enabled = True
 variable_status_leds_caselight_enabled = True
 variable_status_leds_effects_enabled = False
 variable_status_leds_caselight_led_name: "caselight"

--- a/config/hardware/lights/neopixel_caselight_effects.cfg
+++ b/config/hardware/lights/neopixel_caselight_effects.cfg
@@ -2,6 +2,7 @@
 # using LED_effects
 
 [gcode_macro _USER_VARIABLES]
+variable_status_leds_control_enabled = True
 variable_status_leds_caselight_enabled = True
 variable_status_leds_effects_enabled = True
 variable_status_leds_caselight_led_name: "caselight"

--- a/config/hardware/lights/status_leds.cfg
+++ b/config/hardware/lights/status_leds.cfg
@@ -1,6 +1,7 @@
 # Neopixel leds used on the toolhead (stealthburner style)
 
 [gcode_macro _USER_VARIABLES]
+variable_status_leds_control_enabled: True
 variable_status_leds_enabled: True
 variable_status_leds_effects_enabled: False
 variable_status_leds_logo_led_name: "status_leds"

--- a/config/hardware/lights/status_leds_effects.cfg
+++ b/config/hardware/lights/status_leds_effects.cfg
@@ -2,6 +2,7 @@
 # using LED_effects
 
 [gcode_macro _USER_VARIABLES]
+variable_status_leds_control_enabled: True
 variable_status_leds_enabled: True
 variable_status_leds_effects_enabled: True
 variable_status_leds_logo_led_name: "status_leds"

--- a/config/hardware/lights/status_leds_rainbow_barf.cfg
+++ b/config/hardware/lights/status_leds_rainbow_barf.cfg
@@ -2,6 +2,7 @@
 # in a rainbow barf pattern PCB
 
 [gcode_macro _USER_VARIABLES]
+variable_status_leds_control_enabled: True
 variable_status_leds_enabled: True
 variable_status_leds_effects_enabled: False
 variable_status_leds_logo_led_name: "status_leds"

--- a/config/hardware/lights/status_leds_rainbow_barf_effects.cfg
+++ b/config/hardware/lights/status_leds_rainbow_barf_effects.cfg
@@ -2,6 +2,7 @@
 # in a rainbow barf pattern PCB using LED_effects
 
 [gcode_macro _USER_VARIABLES]
+variable_status_leds_control_enabled: True
 variable_status_leds_enabled: True
 variable_status_leds_effects_enabled: True
 variable_status_leds_logo_led_name: "status_leds"

--- a/config/machine.cfg
+++ b/config/machine.cfg
@@ -1,7 +1,7 @@
 [virtual_sdcard]
 path: ~/printer_data/gcodes
 on_error_gcode:
-    {% if printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% if printer["gcode_macro _USER_VARIABLES"].status_leds_control_enabled|default(False) %}
         STATUS_LEDS COLOR="ERROR"
     {% endif %}
     {% if printer["gcode_macro _USER_VARIABLES"].probe_type_enabled == "dockable" or printer["gcode_macro _USER_VARIABLES"].probe_type_enabled == "dockable_virtual" %}
@@ -23,7 +23,7 @@ gcode:
     {% if printer["gcode_macro _USER_VARIABLES"].light_enabled %}
         LIGHT_OFF
     {% endif %}
-    {% if printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% if printer["gcode_macro _USER_VARIABLES"].status_leds_control_enabled|default(False) %}
         STATUS_LEDS COLOR="OFF"
     {% endif %}
 

--- a/macros/base/cancel_print.cfg
+++ b/macros/base/cancel_print.cfg
@@ -9,7 +9,7 @@ gcode:
     {% set mmu_unload_on_cancel_print = printer["gcode_macro _USER_VARIABLES"].mmu_unload_on_cancel_print %}
     {% set filter_enabled = printer["gcode_macro _USER_VARIABLES"].filter_enabled %}
     {% set light_enabled = printer["gcode_macro _USER_VARIABLES"].light_enabled %}
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set status_leds_control_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_control_enabled|default(False) %}
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
     {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
     {% set filter_default_time = printer["gcode_macro _USER_VARIABLES"].filter_default_time_on_end_print|default(600)|int %}
@@ -63,7 +63,7 @@ gcode:
     {% if light_enabled %}
         LIGHT_ON S={light_intensity_end_print}
     {% endif %}
-    {% if status_leds_enabled %}
+    {% if status_leds_control_enabled %}
         STATUS_LEDS COLOR="OFF"
     {% endif %}
 

--- a/macros/base/control.cfg
+++ b/macros/base/control.cfg
@@ -2,7 +2,7 @@
 description: Turn off the printer
 gcode:
     {% set light_enabled = printer["gcode_macro _USER_VARIABLES"].light_enabled %}
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %} 
+    {% set status_leds_control_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_control_enabled|default(False) %}
     {% set display_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_minidisplay_enabled %}
     M84                                                             ; turn steppers off
     TURN_OFF_HEATERS                                                ; turn bed / hotend off
@@ -10,7 +10,7 @@ gcode:
     {% if light_enabled %}
         LIGHT_OFF                                                   ; turn off light
     {% endif %}
-    {% if status_leds_enabled %}
+    {% if status_leds_control_enabled %}
         STATUS_LEDS COLOR="SHUTDOWN"                                     ; turn off status LEDs
     {% endif %}
     {% if display_leds_enabled %}

--- a/macros/base/end_print.cfg
+++ b/macros/base/end_print.cfg
@@ -12,7 +12,7 @@ gcode:
     {% set klippain_mmu_enabled = printer["gcode_macro _USER_VARIABLES"].klippain_mmu_enabled %}
     {% set filter_enabled = printer["gcode_macro _USER_VARIABLES"].filter_enabled %}
     {% set light_enabled = printer["gcode_macro _USER_VARIABLES"].light_enabled %}
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set status_leds_control_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_control_enabled|default(False) %}
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
     {% set filter_default_time = printer["gcode_macro _USER_VARIABLES"].filter_default_time_on_end_print|default(600)|int %}
     {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
@@ -70,7 +70,7 @@ gcode:
         LIGHT_ON S={light_intensity_end_print}
     {% endif %}
 
-    {% if status_leds_enabled %}
+    {% if status_leds_control_enabled %}
         STATUS_LEDS COLOR="DONE_PRINTING"
     {% endif %}
 

--- a/macros/base/homing/homing_beacon_contact.cfg
+++ b/macros/base/homing/homing_beacon_contact.cfg
@@ -149,7 +149,7 @@ variable_saved_accel: 0
 gcode:
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
     {% set homing_travel_accel = printer['gcode_macro _USER_VARIABLES'].homing_travel_accel %}
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set status_leds_control_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_control_enabled|default(False) %}
     {% set probing_active = printer["gcode_macro ACTIVATE_PROBE"].is_active %}
 
     {% set stage = params.STAGE|lower %}
@@ -177,7 +177,7 @@ gcode:
 
         G90
 
-        {% if status_leds_enabled %}
+        {% if status_leds_control_enabled %}
             STATUS_LEDS COLOR="homing"
         {% endif %}
     {% elif post %}
@@ -185,7 +185,7 @@ gcode:
         {% set saved_accel = printer["gcode_macro _HOME_XY"].saved_accel %}
         SET_VELOCITY_LIMIT ACCEL={saved_accel}
 
-        {% if status_leds_enabled %}
+        {% if status_leds_control_enabled %}
             STATUS_LEDS COLOR="ready"
         {% endif %}
     {% endif %}

--- a/macros/base/homing/homing_conditional.cfg
+++ b/macros/base/homing/homing_conditional.cfg
@@ -1,14 +1,14 @@
 [gcode_macro _CG28]
 description: Homing only if necessary
 gcode:
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set status_leds_control_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_control_enabled|default(False) %}
 
     {% if "xyz" not in printer.toolhead.homed_axes %}
-        {% if status_leds_enabled %}
+        {% if status_leds_control_enabled %}
             STATUS_LEDS COLOR="HOMING"
         {% endif %}
         G28
-        {% if status_leds_enabled %}
+        {% if status_leds_control_enabled %}
             STATUS_LEDS COLOR="READY"
         {% endif %}  
     {% endif %}

--- a/macros/base/homing/homing_override.cfg
+++ b/macros/base/homing/homing_override.cfg
@@ -14,7 +14,7 @@ gcode:
     {% set y_driver = printer["gcode_macro _USER_VARIABLES"].y_driver %}
     {% set z_driver = printer["gcode_macro _USER_VARIABLES"].z_driver %}
     {% set z_drop_speed = printer["gcode_macro _USER_VARIABLES"].z_drop_speed * 60 %}
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set status_leds_control_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_control_enabled|default(False) %}
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
 
     {% set homing_first = printer["gcode_macro _USER_VARIABLES"].homing_first|string|upper %}
@@ -33,7 +33,7 @@ gcode:
     # reset parameters
     {% set X, Y, Z = False, False, False %}
 
-    {% if status_leds_enabled %}
+    {% if status_leds_control_enabled %}
         STATUS_LEDS COLOR="HOMING"
     {% endif %}
 
@@ -346,7 +346,7 @@ gcode:
         _EXIT_POINT FUNCTION=homing_override
     {% endif %}
 
-    {% if status_leds_enabled %}
+    {% if status_leds_control_enabled %}
         STATUS_LEDS COLOR="READY"
     {% endif %}
 

--- a/macros/base/homing/z_calibration.cfg
+++ b/macros/base/homing/z_calibration.cfg
@@ -4,9 +4,9 @@ description: Perform the Z calibration using the physical Z endstop and the dock
 gcode:
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set status_leds_control_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_control_enabled|default(False) %}
 
-    {% if status_leds_enabled %}
+    {% if status_leds_control_enabled %}
         STATUS_LEDS COLOR="CALIBRATING_Z"
     {% endif %}
 
@@ -34,6 +34,6 @@ gcode:
         _BASE_CALIBRATE_Z BED_POSITION="{ZRPx},{ZRPy}"
     {% endif %}
 
-    {% if status_leds_enabled %}
+    {% if status_leds_control_enabled %}
         STATUS_LEDS COLOR="READY"
     {% endif %}

--- a/macros/base/probing/overrides/qgl.cfg
+++ b/macros/base/probing/overrides/qgl.cfg
@@ -8,7 +8,7 @@ rename_existing: _BASE_QUAD_GANTRY_LEVEL
 description: Conform a moving, twistable gantry to the shape of a stationary bed with klicky automount
 gcode:
     {% set tilting_travel_accel = printer["gcode_macro _USER_VARIABLES"].tilting_travel_accel %}
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set status_leds_control_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_control_enabled|default(False) %}
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
 
     {% if verbose %}
@@ -17,7 +17,7 @@ gcode:
 
     _CG28
     
-    {% if status_leds_enabled %}
+    {% if status_leds_control_enabled %}
         STATUS_LEDS COLOR="LEVELING"
     {% endif %}
 
@@ -34,6 +34,6 @@ gcode:
 
     DEACTIVATE_PROBE
 
-    {% if status_leds_enabled %}
+    {% if status_leds_control_enabled %}
         STATUS_LEDS COLOR="READY"
     {% endif %}

--- a/macros/base/probing/overrides/z_tilt.cfg
+++ b/macros/base/probing/overrides/z_tilt.cfg
@@ -8,7 +8,7 @@ rename_existing: _BASE_Z_TILT_ADJUST
 description: Conform a moving bed to the shape of a stationary gantry with dockable probe automount
 gcode:
     {% set tilting_travel_accel = printer["gcode_macro _USER_VARIABLES"].tilting_travel_accel %}
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set status_leds_control_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_control_enabled|default(False) %}
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
 
 
@@ -18,7 +18,7 @@ gcode:
     
     _CG28
 
-    {% if status_leds_enabled %}
+    {% if status_leds_control_enabled %}
         STATUS_LEDS COLOR="LEVELING"
     {% endif %}
 
@@ -35,6 +35,6 @@ gcode:
 
     DEACTIVATE_PROBE
 
-    {% if status_leds_enabled %}
+    {% if status_leds_control_enabled %}
         STATUS_LEDS COLOR="READY"
     {% endif %}

--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -58,7 +58,7 @@ gcode:
     {% set light_enabled = printer["gcode_macro _USER_VARIABLES"].light_enabled %}
     {% set light_intensity_start_print = printer["gcode_macro _USER_VARIABLES"].light_intensity_start_print %}
     {% set light_intensity_printing = printer["gcode_macro _USER_VARIABLES"].light_intensity_printing %}
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set status_leds_control_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_control_enabled|default(False) %}
     {% set force_homing_in_start_print = printer["gcode_macro _USER_VARIABLES"].force_homing_in_start_print %}
     {% set klippain_mmu_enabled = printer["gcode_macro _USER_VARIABLES"].klippain_mmu_enabled %}
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
@@ -82,7 +82,7 @@ gcode:
     # --------------------------------
     # Let's do the START_PRINT actions
     # --------------------------------
-    {% if status_leds_enabled %}
+    {% if status_leds_control_enabled %}
         STATUS_LEDS COLOR="BUSY"
     {% endif %}
 
@@ -216,7 +216,7 @@ gcode:
     {% endif %}
 
     # And.... Goooo!
-    {% if status_leds_enabled %}
+    {% if status_leds_control_enabled %}
         STATUS_LEDS COLOR="PRINTING"
     {% endif %}
 
@@ -261,7 +261,7 @@ gcode:
     {% set SOAK = printer["gcode_macro START_PRINT"].soak %}
     {% set CHAMBER_TEMP = printer["gcode_macro START_PRINT"].chamber_temp %}
 
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set status_leds_control_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_control_enabled|default(False) %}
     {% set filter_enabled = printer["gcode_macro _USER_VARIABLES"].filter_enabled %}
 
     {% set St = printer["gcode_macro _USER_VARIABLES"].travel_speed * 60 %}
@@ -269,7 +269,7 @@ gcode:
     {% set max_x = printer.toolhead.axis_maximum.x|float %}
     {% set max_y = printer.toolhead.axis_maximum.y|float %}
 
-    {% if status_leds_enabled %}
+    {% if status_leds_control_enabled %}
         STATUS_LEDS COLOR="HEATING"
     {% endif %}
 
@@ -351,7 +351,7 @@ gcode:
     {% set INITIAL_TOOL = printer["gcode_macro START_PRINT"].initial_tool %}
 
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set status_leds_control_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_control_enabled|default(False) %}
     {% set klippain_mmu_enabled = printer["gcode_macro _USER_VARIABLES"].klippain_mmu_enabled %}
     {% set purge_and_brush_enabled = printer["gcode_macro _USER_VARIABLES"].purge_and_brush_enabled %}
     {% set purgeclean_servo_enabled = printer["gcode_macro _USER_VARIABLES"].purgeclean_servo_enabled %}
@@ -362,7 +362,7 @@ gcode:
     {% set max_x = printer.toolhead.axis_maximum.x|float %}
     {% set max_y = printer.toolhead.axis_maximum.y|float %}
 
-    {% if status_leds_enabled %}
+    {% if status_leds_control_enabled %}
         STATUS_LEDS COLOR="HEATING"
     {% endif %}
 
@@ -458,7 +458,7 @@ gcode:
 
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set status_leds_control_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_control_enabled|default(False) %}
 
     {% if bed_mesh_enabled %}
         {% if BED_MESH_PROFILE == "" %}
@@ -479,11 +479,11 @@ gcode:
 gcode:
     # Preheat the nozzle to safe probing temperature.
     {% set safe_extruder_temp = printer["gcode_macro _USER_VARIABLES"].safe_extruder_temp|float %}
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set status_leds_control_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_control_enabled|default(False) %}
     {% set probe_type_enabled = printer["gcode_macro _USER_VARIABLES"].probe_type_enabled %}
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
 
-    {% if status_leds_enabled %}
+    {% if status_leds_control_enabled %}
         STATUS_LEDS COLOR="HEATING"
     {% endif %}
     {% if verbose %}
@@ -589,6 +589,7 @@ gcode:
     #   ## Your custom code here
 
 
+
 [gcode_macro _MODULE_CUSTOM9]
 gcode:
     # ---- CUSTOM Macro section
@@ -597,4 +598,3 @@ gcode:
     # [gcode_macro _MODULE_CUSTOM8]
     # gcode:
     #   ## Your custom code here
-

--- a/macros/helpers/nozzle_cleaning.cfg
+++ b/macros/helpers/nozzle_cleaning.cfg
@@ -3,7 +3,7 @@ description: Wipe the nozzle on the brush
 gcode:
     {% set purge_and_brush_enabled = printer["gcode_macro _USER_VARIABLES"].purge_and_brush_enabled %}
     {% set purgeclean_servo_enabled = printer["gcode_macro _USER_VARIABLES"].purgeclean_servo_enabled %}
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set status_leds_control_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_control_enabled|default(False) %}
     {% set brush_clean_accel = printer["gcode_macro _USER_VARIABLES"].brush_clean_accel %}
     {% set brush_over_y_axis = printer["gcode_macro _USER_VARIABLES"].brush_over_y_axis %}
     {% set brush_offset = printer["gcode_macro _USER_VARIABLES"].brush_center_offset|default(0)|float %}
@@ -19,7 +19,7 @@ gcode:
         {% set Bx, By, Bz = printer["gcode_macro _USER_VARIABLES"].brush_xyz|map('float') %}
         {% set Bx = Bx + brush_offset %}
 
-        {% if status_leds_enabled %}
+        {% if status_leds_control_enabled %}
             STATUS_LEDS COLOR="CLEANING"
         {% endif %}
 
@@ -69,7 +69,7 @@ gcode:
         {% endif %}
     {% endif %}
 
-    {% if status_leds_enabled %}
+    {% if status_leds_control_enabled %}
         STATUS_LEDS COLOR="READY"
     {% endif %}
 
@@ -85,7 +85,7 @@ gcode:
 
     {% set purge_and_brush_enabled = printer["gcode_macro _USER_VARIABLES"].purge_and_brush_enabled %}
     {% set purgeclean_servo_enabled = printer["gcode_macro _USER_VARIABLES"].purgeclean_servo_enabled %}
-    {% set status_leds_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_enabled %}
+    {% set status_leds_control_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_control_enabled|default(False) %}
     {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
     {% set re_enable_filament_sensor = 0 %}
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
@@ -94,7 +94,7 @@ gcode:
         {% set St = printer["gcode_macro _USER_VARIABLES"].travel_speed * 60 %}
         {% set Sz = printer["gcode_macro _USER_VARIABLES"].z_drop_speed * 60 %}
         
-        {% if status_leds_enabled %}
+        {% if status_leds_control_enabled %}
             STATUS_LEDS COLOR="CLEANING"
         {% endif %}
         
@@ -137,7 +137,7 @@ gcode:
         {% endif %}
     {% endif %}
 
-    {% if status_leds_enabled %}
+    {% if status_leds_control_enabled %}
         STATUS_LEDS COLOR="READY"
     {% endif %}
 

--- a/macros/miscs/startup.cfg
+++ b/macros/miscs/startup.cfg
@@ -51,18 +51,25 @@ gcode:
 
 [gcode_macro _INIT_LEDS]
 gcode:
-    {% if printer["gcode_macro _USER_VARIABLES"].status_leds_enabled or printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled %}
+    {% set light_enabled = printer["gcode_macro _USER_VARIABLES"].light_enabled|default(False) %}
+    {% set status_leds_control_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_control_enabled|default(False) %}
+
+    {% if light_enabled or status_leds_control_enabled %}
         {% if printer["gcode_macro _USER_VARIABLES"].caselight_on_at_startup|default(False) %}
             {% set light_intensity_startup = printer["gcode_macro _USER_VARIABLES"].light_intensity_startup|default(100) %}
-            {% if printer["gcode_macro _USER_VARIABLES"].light_enabled %}
+            {% if light_enabled %}
                 LIGHT_ON S={light_intensity_startup}
             {% endif %}
-            STATUS_LEDS COLOR="READY"
+            {% if status_leds_control_enabled %}
+                STATUS_LEDS COLOR="READY"
+            {% endif %}
         {% else %}
-            {% if printer["gcode_macro _USER_VARIABLES"].light_enabled %}
+            {% if light_enabled %}
                 LIGHT_OFF
             {% endif %}
-            STATUS_LEDS COLOR="OFF"
+            {% if status_leds_control_enabled %}
+                STATUS_LEDS COLOR="OFF"
+            {% endif %}
         {% endif %}
     {% endif %}
 


### PR DESCRIPTION
Fixes Neopixel caselight-only setups where Klippain would define a valid `STATUS_LEDS` target but most macros would never call it.

Previously, macro callers used `status_leds_enabled` as the gate for `STATUS_LEDS`. That variable specifically means toolhead logo/nozzle status LEDs are enabled, so caselight-only configs with `status_leds_caselight_enabled`
were skipped.

This adds a hardware-driven `status_leds_control_enabled` capability for light configs that provide the shared `STATUS_LEDS` control path. Macro callers now use that aggregate capability, while the `STATUS_LEDS` macro itself
still gates each LED target independently.

## Key Changes

- Add `status_leds_control_enabled` to Neopixel status/caselight light profiles.
- Use `status_leds_control_enabled|default(False)` before calling `STATUS_LEDS`.
- Keep internal `STATUS_LEDS` handling split by target:
- `status_leds_enabled` for toolhead logo/nozzle LEDs
- `status_leds_caselight_enabled` for Neopixel caselight LEDs
- `status_leds_minidisplay_enabled` for display LEDs
- Update startup LED handling so `fcob_white`-only lighting still responds to `caselight_on_at_startup`.

See also #541, #561 