### PR TITLE
feat: sort installer MCU menus and prettify template names

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -146,9 +146,36 @@ function install_config {
 }
 
 
+# Helper function to convert a template filename to a friendlier display name
+function format_template_display_name {
+    local display_name
+    display_name="${1%.cfg}"
+    display_name="${display_name//_/ }"
+    display_name="${display_name//-/ }"
+    display_name="$(printf '%s\n' "${display_name}" | tr -s ' ' | sed -E 's/(^| )V([0-9])/\1v\2/g')"
+
+    if [[ "${display_name}" == "MY OWN CUSTOM TEMPLATE" ]]; then
+        display_name="My Own Custom Template"
+    fi
+
+    printf '%s\n' "${display_name}"
+}
+
+# Helper function to build sorted "display name <tab> file path" entries for a template directory
+function build_template_menu_entries {
+    local template_dir="$1"
+    local file display_name
+
+    while IFS= read -r -d '' file; do
+        display_name="$(format_template_display_name "$(basename "${file}")")"
+        printf '%s\t%s\n' "${display_name}" "${file}"
+    done < <(find "${template_dir}" -maxdepth 1 -type f -name '*.cfg' -print0) | sort -f
+}
+
 # Helper function to ask and install the MCU templates if needed
 function install_mcu_templates {
-    local install_template file_list main_template install_toolhead_template toolhead_template install_mmu_template
+    local install_template file_list display_list main_template install_toolhead_template toolhead_template install_mmu_template install_expander_template expander_template
+    local display_name selected_file selected_name
 
     read < /dev/tty -rp "[CONFIG] Would you like to select and install MCU wiring templates files? (Y/n) " install_template
     if [[ -z "$install_template" ]]; then
@@ -164,20 +191,23 @@ function install_mcu_templates {
 
     # If "yes" was selected, let's continue the install by listing the main MCU template
     file_list=()
-    while IFS= read -r -d '' file; do
-        file_list+=("$file")
-    done < <(find "${FRIX_CONFIG_PATH}/user_templates/mcu_defaults/main" -maxdepth 1 -type f -print0)
+    display_list=()
+    while IFS=$'\t' read -r display_name selected_file; do
+        file_list+=("${selected_file}")
+        display_list+=("${display_name}")
+    done < <(build_template_menu_entries "${FRIX_CONFIG_PATH}/user_templates/mcu_defaults/main")
     echo "[CONFIG] Please select your main MCU in the following list:"
     for i in "${!file_list[@]}"; do
-        echo "  $((i+1))) $(basename "${file_list[i]}")"
+        echo "  $((i+1))) ${display_list[i]}"
     done
 
     read < /dev/tty -p "[CONFIG] Template to install (or 0 to skip): " main_template
     if [[ "$main_template" -gt 0 ]]; then
         # If the user selected a file, copy its content into the mcu.cfg file
-        filename=$(basename "${file_list[$((main_template-1))]}")
-        cat "${FRIX_CONFIG_PATH}/user_templates/mcu_defaults/main/$filename" >> ${USER_CONFIG_PATH}/mcu.cfg
-        printf "[CONFIG] Template '$filename' inserted into your mcu.cfg user file\n\n"
+        selected_file="${file_list[$((main_template-1))]}"
+        selected_name="${display_list[$((main_template-1))]}"
+        cat "${selected_file}" >> ${USER_CONFIG_PATH}/mcu.cfg
+        printf "[CONFIG] Template '%s' inserted into your mcu.cfg user file\n\n" "${selected_name}"
     else
         printf "[CONFIG] No template selected. Skip and continuing...\n\n"
     fi
@@ -192,20 +222,23 @@ function install_mcu_templates {
     # Check if the user wants to install a toolhead MCU template
     if [[ "$install_toolhead_template" =~ ^(yes|y)$ ]]; then
         file_list=()
-        while IFS= read -r -d '' file; do
-            file_list+=("$file")
-        done < <(find "${FRIX_CONFIG_PATH}/user_templates/mcu_defaults/toolhead" -maxdepth 1 -type f -print0)
+        display_list=()
+        while IFS=$'\t' read -r display_name selected_file; do
+            file_list+=("${selected_file}")
+            display_list+=("${display_name}")
+        done < <(build_template_menu_entries "${FRIX_CONFIG_PATH}/user_templates/mcu_defaults/toolhead")
         echo "[CONFIG] Please select your toolhead MCU in the following list:"
         for i in "${!file_list[@]}"; do
-            echo "  $((i+1))) $(basename "${file_list[i]}")"
+            echo "  $((i+1))) ${display_list[i]}"
         done
 
         read < /dev/tty -p "[CONFIG] Template to install (or 0 to skip): " toolhead_template
         if [[ "$toolhead_template" -gt 0 ]]; then
             # If the user selected a file, copy its content into the mcu.cfg file
-            filename=$(basename "${file_list[$((toolhead_template-1))]}")
-            cat "${FRIX_CONFIG_PATH}/user_templates/mcu_defaults/toolhead/$filename" >> ${USER_CONFIG_PATH}/mcu.cfg
-            printf "[CONFIG] Template '$filename' inserted into your mcu.cfg user file\n\n"
+            selected_file="${file_list[$((toolhead_template-1))]}"
+            selected_name="${display_list[$((toolhead_template-1))]}"
+            cat "${selected_file}" >> ${USER_CONFIG_PATH}/mcu.cfg
+            printf "[CONFIG] Template '%s' inserted into your mcu.cfg user file\n\n" "${selected_name}"
         else
             printf "[CONFIG] No toolhead template selected. Skip and continuing...\n\n"
         fi
@@ -221,27 +254,30 @@ function install_mcu_templates {
     # Check if the user wants to install an MMU/ERCF MCU template
     if [[ "$install_mmu_template" =~ ^(yes|y)$ ]]; then
         file_list=()
-        while IFS= read -r -d '' file; do
-            file_list+=("$file")
-        done < <(find "${FRIX_CONFIG_PATH}/user_templates/mcu_defaults/mmu" -maxdepth 1 -type f -print0)
+        display_list=()
+        while IFS=$'\t' read -r display_name selected_file; do
+            file_list+=("${selected_file}")
+            display_list+=("${display_name}")
+        done < <(build_template_menu_entries "${FRIX_CONFIG_PATH}/user_templates/mcu_defaults/mmu")
         echo "[CONFIG] Please select your MMU/ERCF MCU in the following list:"
         for i in "${!file_list[@]}"; do
-            echo "  $((i+1))) $(basename "${file_list[i]}")"
+            echo "  $((i+1))) ${display_list[i]}"
         done
 
         read < /dev/tty -p "[CONFIG] Template to install (or 0 to skip): " mmu_template
         if [[ "$mmu_template" -gt 0 ]]; then
             # If the user selected a file, copy its content into the mcu.cfg file
-            filename=$(basename "${file_list[$((mmu_template-1))]}")
-            cat "${FRIX_CONFIG_PATH}/user_templates/mcu_defaults/mmu/$filename" >> ${USER_CONFIG_PATH}/mcu.cfg
-            echo "[CONFIG] Template '$filename' inserted into your mcu.cfg user file"
+            selected_file="${file_list[$((mmu_template-1))]}"
+            selected_name="${display_list[$((mmu_template-1))]}"
+            cat "${selected_file}" >> ${USER_CONFIG_PATH}/mcu.cfg
+            printf "[CONFIG] Template '%s' inserted into your mcu.cfg user file\n" "${selected_name}"
             printf "[CONFIG] Note: keep in mind that you have to install the HappyHare backend manually to use an MMU/ERCF with Klippain. See the Klippain documentation for more information!\n\n"
         else
             printf "[CONFIG] No MMU/ERCF template selected. Skip and continuing...\n\n"
         fi
     fi
 
-   # Finally see if the user use an expander board
+    # Finally see if the user use an expander board
     read < /dev/tty -rp "[CONFIG] Do you have an expander board and want to install a template? (y/N) " install_expander_template
     if [[ -z "$install_expander_template" ]]; then
         install_expander_template="n"
@@ -251,20 +287,23 @@ function install_mcu_templates {
     # Check if the user wants to install an expander MCU template
     if [[ "$install_expander_template" =~ ^(yes|y)$ ]]; then
         file_list=()
-        while IFS= read -r -d '' file; do
-            file_list+=("$file")
-        done < <(find "${FRIX_CONFIG_PATH}/user_templates/mcu_defaults/expand" -maxdepth 1 -type f -print0)
+        display_list=()
+        while IFS=$'\t' read -r display_name selected_file; do
+            file_list+=("${selected_file}")
+            display_list+=("${display_name}")
+        done < <(build_template_menu_entries "${FRIX_CONFIG_PATH}/user_templates/mcu_defaults/expander")
         echo "[CONFIG] Please select your expander MCU in the following list:"
         for i in "${!file_list[@]}"; do
-            echo "  $((i+1))) $(basename "${file_list[i]}")"
+            echo "  $((i+1))) ${display_list[i]}"
         done
 
         read < /dev/tty -p "[CONFIG] Template to install (or 0 to skip): " expander_template
         if [[ "$expander_template" -gt 0 ]]; then
             # If the user selected a file, copy its content into the mcu.cfg file
-            filename=$(basename "${file_list[$((expander_template-1))]}")
-            cat "${FRIX_CONFIG_PATH}/user_templates/mcu_defaults/expand/$filename" >> ${USER_CONFIG_PATH}/mcu.cfg
-            printf "[CONFIG] Template '$filename' inserted into your mcu.cfg user file\n\n"
+            selected_file="${file_list[$((expander_template-1))]}"
+            selected_name="${display_list[$((expander_template-1))]}"
+            cat "${selected_file}" >> ${USER_CONFIG_PATH}/mcu.cfg
+            printf "[CONFIG] Template '%s' inserted into your mcu.cfg user file\n\n" "${selected_name}"
         else
             printf "[CONFIG] No expander template selected. Skip and continuing...\n\n"
         fi

--- a/tests/install_mcu_templates_test.sh
+++ b/tests/install_mcu_templates_test.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(CDPATH= cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+
+assert_eq() {
+    local expected="$1"
+    local actual="$2"
+    local message="$3"
+
+    if [[ "${expected}" != "${actual}" ]]; then
+        printf 'FAIL: %s\nexpected: %s\nactual:   %s\n' "${message}" "${expected}" "${actual}" >&2
+        exit 1
+    fi
+}
+
+tmpdir="$(mktemp -d)"
+loader="$(mktemp)"
+trap 'rm -rf "${tmpdir}"; rm -f "${loader}"' EXIT
+
+awk '/^BACKUP_DIR=/{exit} {print}' "${repo_root}/install.sh" > "${loader}"
+# shellcheck disable=SC1090
+source "${loader}"
+
+touch "${tmpdir}/LDO_Leviathan_v1.2.cfg"
+touch "${tmpdir}/BTT_Manta_M8P_v1.1.cfg"
+touch "${tmpdir}/MY-OWN-CUSTOM-TEMPLATE.cfg"
+
+entries=()
+while IFS= read -r entry; do
+    entries+=("${entry}")
+done < <(build_template_menu_entries "${tmpdir}")
+
+assert_eq 3 "${#entries[@]}" "expected one menu entry per template file"
+assert_eq "BTT Manta M8P v1.1	${tmpdir}/BTT_Manta_M8P_v1.1.cfg" "${entries[0]}" "entries should be sorted by human-readable label"
+assert_eq "LDO Leviathan v1.2	${tmpdir}/LDO_Leviathan_v1.2.cfg" "${entries[1]}" "underscores should be rendered as spaces"
+assert_eq "My Own Custom Template	${tmpdir}/MY-OWN-CUSTOM-TEMPLATE.cfg" "${entries[2]}" "special template should get title-cased output"
+
+template_categories=()
+while IFS= read -r category; do
+    template_categories+=("${category}")
+done < <(find "${repo_root}/user_templates/mcu_defaults" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort)
+assert_eq "expander main mmu toolhead" "${template_categories[*]}" "expected installer coverage for every MCU template category"
+
+for category in "${template_categories[@]}"; do
+    if ! grep -q "mcu_defaults/${category}" "${repo_root}/install.sh"; then
+        printf 'FAIL: installer does not reference mcu_defaults/%s\n' "${category}" >&2
+        exit 1
+    fi
+done
+
+if grep -q 'mcu_defaults/expand"' "${repo_root}/install.sh"; then
+    printf 'FAIL: installer still references stale mcu_defaults/expand path\n' >&2
+    exit 1
+fi
+
+printf 'ok\n'


### PR DESCRIPTION
Sort the main, toolhead, and MMU template menus by a human-readable label instead of raw filesystem order so the installer list is predictable again.\n\nAlso format displayed template names from raw filenames like BTT_Manta_M8P_v1.1.cfg into friendlier labels such as BTT Manta M8P v1.1 while still copying the original selected file. Add a focused shell regression test to lock in the menu entry formatting and ordering.

Closes #545 