### PR TITLE
fix: Harden fan tachometer checks

### DIFF
--- a/macros/base/cancel_print.cfg
+++ b/macros/base/cancel_print.cfg
@@ -13,7 +13,7 @@ gcode:
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
     {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
     {% set filter_default_time = printer["gcode_macro _USER_VARIABLES"].filter_default_time_on_end_print|default(600)|int %}
-    {% set hotend_fan_tach_enabled = printer["gcode_macro _USER_VARIABLES"].hotend_fan_tach_enabled %}
+    {% set hotend_fan_tach_enabled = printer["gcode_macro _USER_VARIABLES"].hotend_fan_tach_enabled|default(False) %}
     {% set retract_length = printer["gcode_macro _USER_VARIABLES"].retract_length|default(20)|float %}
     
     PARK

--- a/macros/base/end_print.cfg
+++ b/macros/base/end_print.cfg
@@ -16,7 +16,7 @@ gcode:
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
     {% set filter_default_time = printer["gcode_macro _USER_VARIABLES"].filter_default_time_on_end_print|default(600)|int %}
     {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
-    {% set hotend_fan_tach_enabled = printer["gcode_macro _USER_VARIABLES"].hotend_fan_tach_enabled %}
+    {% set hotend_fan_tach_enabled = printer["gcode_macro _USER_VARIABLES"].hotend_fan_tach_enabled|default(False) %}
 
     PARK
 
@@ -126,7 +126,7 @@ gcode:
 gcode:
     # ----- TURN OFF FANS -------------------------------------
     # Turn off fans and fan monitoring at the end of a print job
-    {% set hotend_fan_tach_enabled = printer["gcode_macro _USER_VARIABLES"].hotend_fan_tach_enabled %}
+    {% set hotend_fan_tach_enabled = printer["gcode_macro _USER_VARIABLES"].hotend_fan_tach_enabled|default(False) %}
 
     {% if hotend_fan_tach_enabled %}
         UPDATE_DELAYED_GCODE ID=_BACKGROUND_HOTEND_TACHO_CHECK DURATION=0

--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -65,8 +65,8 @@ gcode:
     {% set firmware_retraction_enabled = printer["gcode_macro _USER_VARIABLES"].firmware_retraction_enabled %}
     {% set filter_enabled = printer["gcode_macro _USER_VARIABLES"].filter_enabled %}
     {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled %}
-    {% set part_fan_tach_enabled = printer["gcode_macro _USER_VARIABLES"].part_fan_tach_enabled %}
-    {% set hotend_fan_tach_enabled = printer["gcode_macro _USER_VARIABLES"].hotend_fan_tach_enabled %}
+    {% set part_fan_tach_enabled = printer["gcode_macro _USER_VARIABLES"].part_fan_tach_enabled|default(False) %}
+    {% set hotend_fan_tach_enabled = printer["gcode_macro _USER_VARIABLES"].hotend_fan_tach_enabled|default(False) %}
 
     {% if MATERIAL not in printer["gcode_macro _USER_VARIABLES"].material_parameters %}
         RESPOND MSG="Material '{MATERIAL}' is unknown!"

--- a/macros/helpers/tachometer_check.cfg
+++ b/macros/helpers/tachometer_check.cfg
@@ -39,6 +39,6 @@ gcode:
         {% else %}
             M400
             CANCEL_PRINT
-            {action_raise_error("Hotend fan stoppage detected, print was canceled!")}
+            {action_raise_error("Part fan stoppage detected, print was canceled!")}
         {% endif %}
     {% endif %}


### PR DESCRIPTION
Default optional fan tachometer flags to false when their hardware include is not active and correct the part fan tachometer failure message so it no longer reports a hotend fan stoppage.