### PR TITLE
fix: Clamp park Z against transformed toolhead position

### DIFF
--- a/macros/base/park.cfg
+++ b/macros/base/park.cfg
@@ -15,12 +15,18 @@ gcode:
     {% set St = printer["gcode_macro _USER_VARIABLES"].travel_speed * 60 %}
     {% set Sz = printer["gcode_macro _USER_VARIABLES"].z_drop_speed * 60 %}
 
-    {% set max_z = printer.toolhead.axis_maximum.z - printer.gcode_move.homing_origin.z |float %}
+    {% set max_z = printer.toolhead.axis_maximum.z|float %}
     {% set act_z = printer.toolhead.position.z|float %}
+    {% set gcode_z = printer.gcode_move.gcode_position.z|float %}
+    {% set z_margin = 1.0 %}
 
-    {% set z_safe = act_z + Z_HOP %}
-    {% if z_safe > max_z %}
-        {% set z_safe = max_z %}
+    {% set max_gcode_z = gcode_z + max_z - act_z - z_margin %}
+    {% set z_safe = gcode_z + Z_HOP %}
+    {% if z_safe > max_gcode_z %}
+        {% set z_safe = max_gcode_z %}
+    {% endif %}
+    {% if z_safe < gcode_z %}
+        {% set z_safe = gcode_z %}
     {% endif %}
 
     {% if printer.toolhead.homed_axes != "xyz" %}


### PR DESCRIPTION
PARK previously clamped the requested Z move with homing_origin only, which missed active G-code transforms such as bed mesh. Calculate the commandable Z ceiling from the current gcode/toolhead delta and leave a small buffer before moving to the park XY position.