### PR TITLE
docs: Explain print action customization

### DIFF
--- a/docs/overrides.md
+++ b/docs/overrides.md
@@ -59,3 +59,57 @@ You can even redefine a full macro! For example if the default Klippain prime li
 gcode:
   # Put your custom prime line G-code here...
 ```
+
+## Custom START_PRINT and END_PRINT actions
+
+`START_PRINT` and `END_PRINT` are built from ordered action lists in `_USER_VARIABLES`.
+Override these lists in `overrides.cfg` to reorder actions, remove actions,
+duplicate actions, or insert your own custom actions.
+
+Built-in `START_PRINT` actions are `bed_soak`, `extruder_preheating`,
+`chamber_soak`, `extruder_heating`, `tilt_calib`, `z_offset`, `beacon_calib`,
+`bedmesh`, `purge`, `clean`, and `primeline`.
+
+Built-in `END_PRINT` actions are `retract_filament`, `turn_off_heaters`,
+`turn_off_fans`, `turn_off_motors`, and `reset_limits`.
+
+Example:
+```
+[gcode_macro _USER_VARIABLES]
+variable_startprint_actions: "bed_soak", "extruder_preheating", "my_start_action", "bedmesh", "primeline"
+variable_endprint_actions: "retract_filament", "my_end_action", "turn_off_heaters", "turn_off_fans"
+gcode:
+```
+
+The preferred way to add a custom action is to add its name to the list and define
+its matching macro in `overrides.cfg`. Use lowercase letters, numbers, and
+underscores for custom action names. Klippain uppercases the action name and calls
+`_START_PRINT_ACTION_<NAME>` or `_END_PRINT_ACTION_<NAME>`.
+
+For a custom `START_PRINT` action named `my_start_action`:
+```
+[gcode_macro _START_PRINT_ACTION_MY_START_ACTION]
+gcode:
+  # Put your custom START_PRINT G-code here...
+```
+
+For a custom `END_PRINT` action named `my_end_action`:
+```
+[gcode_macro _END_PRINT_ACTION_MY_END_ACTION]
+gcode:
+  # Put your custom END_PRINT G-code here...
+```
+
+Custom action macros receive the original `START_PRINT` or `END_PRINT` parameters,
+so values such as `BED_TEMP`, `EXTRUDER_TEMP`, `MATERIAL`, or `FILTER_TIME` are
+available through `params` when they were passed to the parent macro.
+
+If a custom action is listed but its matching macro does not exist, Klippain raises
+an error instead of silently skipping it.
+
+`START_PRINT` also keeps the older `custom1` through `custom9` action slots for
+compatibility. If `variable_startprint_actions` contains `custom1`, Klippain calls
+`_MODULE_CUSTOM1`; if it contains `custom9`, Klippain calls `_MODULE_CUSTOM9`, and
+so on. These slots only exist for `START_PRINT`. For new custom actions, prefer the
+named `_START_PRINT_ACTION_<NAME>` pattern because it is clearer and does not limit
+you to nine custom actions.

--- a/macros/base/end_print.cfg
+++ b/macros/base/end_print.cfg
@@ -30,8 +30,8 @@ gcode:
     # to do the procedure in the correct order or a custom user override.
     #
     # Custom actions can be called by defining a gcode macro as in the following example
-    # and adding `custom1` to the endprint_actions override config.
-    # [gcode_macro _END_PRINT_ACTION_CUSTOM1]
+    # and adding `my_end_action` to the endprint_actions override config.
+    # [gcode_macro _END_PRINT_ACTION_MY_END_ACTION]
     # gcode:
     #   ## Your custom code here
     #

--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -145,8 +145,8 @@ gcode:
     # to do the procedure in the correct order for the configured probe (or user custom override)
     #
     # Custom actions can be called by defining a gcode macro as in the following example and
-    # adding `custom1` to the startprint_actions override config.
-    # [gcode_macro _START_PRINT_ACTION_CUSTOM1]
+    # adding `my_start_action` to the startprint_actions override config.
+    # [gcode_macro _START_PRINT_ACTION_MY_START_ACTION]
     # gcode:
     #   ## Your custom code here
     #
@@ -594,7 +594,6 @@ gcode:
     # ---- CUSTOM Macro section
     # this section is reserved for personal customized start actions, which can be combined with all other start actions
     # in order to use this, create a new macro in overrides.cfg
-    # [gcode_macro _MODULE_CUSTOM8]
+    # [gcode_macro _MODULE_CUSTOM9]
     # gcode:
     #   ## Your custom code here
-

--- a/user_templates/overrides.cfg
+++ b/user_templates/overrides.cfg
@@ -26,7 +26,15 @@
 ## The START_PRINT sequence is modular and fully customizable. A default START_PRINT sequence is auto-populated based on
 ## your probe choice (TAP, Dockable, Inductive), but if for some reasons you still want to modify it, please uncomment the following 3
 ## lines to define a new `variable_startprint_actions`. You can use any number of action or even duplicate some actions if needed.
-## Available actions: "bed_soak", "extruder_preheating", "chamber_soak", "extruder_heating", "tilt_calib", "z_offset", "bedmesh", "purge", "clean", "primeline"
+## Available actions: "bed_soak", "extruder_preheating", "chamber_soak", "extruder_heating", "tilt_calib",
+##                    "z_offset", "beacon_calib", "bedmesh", "purge", "clean", "primeline"
+## Custom actions can be added with a matching `_START_PRINT_ACTION_<NAME>` macro. Example:
+##   variable_startprint_actions: "bed_soak", "my_start_action", "bedmesh", "primeline"
+##   [gcode_macro _START_PRINT_ACTION_MY_START_ACTION]
+##   gcode:
+##     ## Your custom START_PRINT G-code here
+## Legacy START_PRINT custom slots "custom1" through "custom9" are also available and call
+## `_MODULE_CUSTOM1` through `_MODULE_CUSTOM9`.
 ##
 # [gcode_macro _USER_VARIABLES]
 # variable_startprint_actions: "action1", "action2", ...
@@ -35,7 +43,13 @@
 ## The END_PRINT sequence is modular and fully customizable. A default END_PRINT sequence is auto-populated, but if for
 ## some reasons you still want to modify it, please uncomment the following 3 lines to define a new `variable_endprint_actions`.
 ## You can use any number of action or even duplicate some actions if needed.
-## Available actions: "retract_filament", "turn_off_heaters", "turn_off_fans", "turn_off_motors"
+## Available actions: "retract_filament", "turn_off_heaters", "turn_off_fans", "turn_off_motors",
+##                    "reset_limits"
+## Custom actions can be added with a matching `_END_PRINT_ACTION_<NAME>` macro. Example:
+##   variable_endprint_actions: "retract_filament", "my_end_action", "turn_off_heaters"
+##   [gcode_macro _END_PRINT_ACTION_MY_END_ACTION]
+##   gcode:
+##     ## Your custom END_PRINT G-code here
 ##
 # [gcode_macro _USER_VARIABLES]
 # variable_endprint_actions: "action1", "action2", ...


### PR DESCRIPTION
Document the preferred dynamic START_PRINT and END_PRINT action hooks in the overrides guide and template. Also clarify the legacy START_PRINT custom slots and align nearby inline examples with the supported macro names.