### PR TITLE
feat: Add 220mm bed size support

### DIFF
--- a/config/hardware/axis/size/220mm.cfg
+++ b/config/hardware/axis/size/220mm.cfg
@@ -1,0 +1,13 @@
+[stepper_x]
+position_min: 0
+position_endstop: 220
+position_max: 220
+
+[stepper_y]
+position_min: 0
+position_endstop: 220
+position_max: 220
+
+[stepper_z]
+position_max: 250
+position_min: -5

--- a/config/software/bed_mesh/bed_mesh_220mm.cfg
+++ b/config/software/bed_mesh/bed_mesh_220mm.cfg
@@ -1,0 +1,22 @@
+# If this files is included, then it also activate the bed_mesh
+# automatically in the START_PRINT macro
+[gcode_macro _USER_VARIABLES]
+variable_bed_mesh_enabled: True
+gcode:
+
+# Also include directly the dockable probe overide of BED_MESH_CALIBRATE from here
+[include ../../../macros/base/probing/overrides/bed_mesh_calibrate.cfg]
+# And also include the adaptive mesh macro at the same time
+[include ../../../macros/calibration/adaptive_bed_mesh.cfg]
+
+
+[bed_mesh]
+speed: 350
+horizontal_move_z: 20
+mesh_min: 25, 25
+mesh_max: 195, 195
+probe_count: 7, 7
+fade_start: 0.6
+fade_end: 10.0
+algorithm: bicubic
+zero_reference_position: 110, 110

--- a/user_templates/printer.cfg
+++ b/user_templates/printer.cfg
@@ -58,6 +58,7 @@
 ### --------------------------------------------------------------------------------------
 # [include config/hardware/axis/size/120mm.cfg]
 # [include config/hardware/axis/size/180mm.cfg]
+# [include config/hardware/axis/size/220mm.cfg]
 # [include config/hardware/axis/size/250mm.cfg]
 # [include config/hardware/axis/size/300mm.cfg]
 # [include config/hardware/axis/size/350mm.cfg]
@@ -241,6 +242,7 @@
 ### --------------------------------------------------------------------------------------
 # [include config/software/bed_mesh/bed_mesh_120mm.cfg]
 # [include config/software/bed_mesh/bed_mesh_180mm.cfg]
+# [include config/software/bed_mesh/bed_mesh_220mm.cfg]
 # [include config/software/bed_mesh/bed_mesh_250mm.cfg]
 # [include config/software/bed_mesh/bed_mesh_300mm.cfg]
 # [include config/software/bed_mesh/bed_mesh_350mm.cfg]


### PR DESCRIPTION
Add a 220mm axis size profile with 250mm Z height and a matching 220mm bed mesh profile. Expose both includes in the printer template without adding QGL or Z-tilt presets.