### PR TITLE
feat: Add BTT MMB CAN 1.1 and 2.0 templates

### DIFF
--- a/config/mcu_definitions/mmu/BTT_MMB_CAN_v1.1.cfg
+++ b/config/mcu_definitions/mmu/BTT_MMB_CAN_v1.1.cfg
@@ -1,0 +1,24 @@
+[board_pins mmu_manufacturer]
+mcu: mmu
+aliases:
+    # MMB CAN v1.1 swaps M1 enable and STP4 compared with v1.0.
+    MCU_M1_STEP=PB15   , MCU_M1_DIR=PB14   , MCU_M1_EN=PB8    , MCU_M1_UART=PA10   , # MCU_M1_DIAG=PA3   ,
+    MCU_M2_STEP=PD2    , MCU_M2_DIR=PB13   , MCU_M2_EN=PD1    , MCU_M2_UART=PC7    , # MCU_M2_DIAG=PA4   ,
+    MCU_M3_STEP=PD0    , MCU_M3_DIR=PD3    , MCU_M3_EN=PA15   , MCU_M3_UART=PC6    , MCU_M3_DIAG=PB9   ,
+    MCU_M4_STEP=PB6    , MCU_M4_DIR=PB7    , MCU_M4_EN=PB5    , MCU_M4_UART=PA9    , # MCU_M4_DIAG=PA8   ,
+
+    MCU_MISO=PA6  , MCU_SCK=PA5  , MCU_MOSI=PA7  ,
+
+    # STP1-STP4 are also the driver DIAG pins.
+    MCU_STP1=PA3 , MCU_STP2=PA4  , MCU_STP3=PB9  ,
+    MCU_STP4=PA8 , MCU_STP5=PC15 , MCU_STP6=PC13 , MCU_STP7=PC14 , MCU_STP8=PB12 , MCU_STP9=PB11 , MCU_STP10=PB10 , MCU_STP11=PB2 ,
+
+    MCU_MOT=PA0      ,
+    MCU_SENSOR=PA1   ,
+    MCU_RGB=PA2      ,
+
+    ## I2C header
+    MCU_I2C_SDA=PB4  , MCU_I2C_SCL=PB3  ,
+
+    ## SWD header
+    MCU_SWD_PA14=PA14 , MCU_SWD_PA13=PA13 ,

--- a/config/mcu_definitions/mmu/BTT_MMB_CAN_v2.0.cfg
+++ b/config/mcu_definitions/mmu/BTT_MMB_CAN_v2.0.cfg
@@ -1,0 +1,26 @@
+[board_pins mmu_manufacturer]
+mcu: mmu
+aliases:
+    MCU_M1_STEP=PD4    , MCU_M1_DIR=PD3    , MCU_M1_EN=PD5    , MCU_M1_UART=PB5   , MCU_M1_DIAG=PB9   ,
+    MCU_M2_STEP=PC9    , MCU_M2_DIR=PC8    , MCU_M2_EN=PD2    , MCU_M2_UART=PB4   , MCU_M2_DIAG=PB8   ,
+    MCU_M3_STEP=PC15   , MCU_M3_DIR=PC11   , MCU_M3_EN=PC10   , MCU_M3_UART=PB3   , MCU_M3_DIAG=PB7   ,
+    MCU_M4_STEP=PC13   , MCU_M4_DIR=PC12   , MCU_M4_EN=PC14   , MCU_M4_UART=PD6   , MCU_M4_DIAG=PB6   ,
+
+    MCU_STP1=PA15 , MCU_STP2=PA10 , MCU_STP3=PD9  , MCU_STP4=PD8  ,
+
+    ## 2x7 header, lower row
+    MCU_IN_L_0=PC6 , MCU_IN_L_1=PA8 , MCU_IN_L_2=PB11 , MCU_IN_L_3=PB2 , MCU_IN_L_4=PB0 , MCU_IN_L_5=PC4 ,
+
+    ## 2x7 header, upper row
+    MCU_IN_H_0=PC7 , MCU_IN_H_1=PA9 , MCU_IN_H_2=PB12 , MCU_IN_H_3=PB10 , MCU_IN_H_4=PB1 , MCU_IN_H_5=PC5 ,
+
+    ## Happy Hare / ERCF-style stop aliases over the 2x7 header
+    MCU_STP5=PC6  , MCU_STP6=PA8  , MCU_STP7=PB11 , MCU_STP8=PB2  , MCU_STP9=PB0  , MCU_STP10=PC4 ,
+    MCU_STP11=PC5 , MCU_STP12=PB1 , MCU_STP13=PC7 , MCU_STP14=PA9 , MCU_STP15=PB12 , MCU_STP16=PB10 ,
+
+    MCU_MOT1=PA1    , MCU_MOT2=PA0    ,
+    MCU_SENSOR=PC2  ,
+    MCU_RGB=PC3     ,
+
+    ## I2C header
+    MCU_I2C_SCL=PC0  , MCU_I2C_SDA=PC1  ,

--- a/user_templates/mcu_defaults/mmu/BTT_MMB_CAN_v1.1.cfg
+++ b/user_templates/mcu_defaults/mmu/BTT_MMB_CAN_v1.1.cfg
@@ -1,0 +1,52 @@
+
+#-----------------------------------------------#
+#### BTT MMB CAN v1.1 board MCU definition ######
+#-----------------------------------------------#
+
+[mcu mmu]
+##--------------------------------------------------------------------
+serial: /dev/serial/by-id/change-me-to-the-correct-mcu-path
+# canbus_uuid: change-me-to-the-correct-canbus-id
+##--------------------------------------------------------------------
+
+# If you want to override the wiring of the BTT MMB CAN board, keep in mind that this
+# board is defined using the "mmu" name. So you should use "pin: mmu:PIN_NAME"
+# in your own overrides.cfg files.
+
+[include config/mcu_definitions/mmu/BTT_MMB_CAN_v1.1.cfg] # Do not remove this line
+[board_pins mmu_mcu]
+mcu: mmu
+aliases:
+    MMU_GEAR_STEP=MCU_M1_STEP  , MMU_GEAR_DIR=MCU_M1_DIR  , MMU_GEAR_ENABLE=MCU_M1_EN  , MMU_GEAR_UART=MCU_M1_UART  ,
+    MMU_SEL_STEP=MCU_M2_STEP   , MMU_SEL_DIR=MCU_M2_DIR   , MMU_SEL_ENABLE=MCU_M2_EN   , MMU_SEL_UART=MCU_M2_UART   ,
+
+    MMU_GEAR_DIAG=MCU_STP1 , # M1 DIAG
+    MMU_SEL_DIAG=MCU_STP2  , # M2 DIAG
+
+    MMU_SEL_ENDSTOP=MCU_STP11  ,
+
+    MMU_SERVO=MCU_MOT          ,
+    MMU_ENCODER=MCU_SENSOR     ,
+    MMU_NEOPIXEL=MCU_RGB       ,
+    # MMU_GATE_SENSOR=MCU_STP1  , # (if not GEAR DIAG!)
+
+    MMU_PRE_GATE_0=MCU_STP3    ,
+    MMU_PRE_GATE_1=MCU_STP4    ,
+    MMU_PRE_GATE_2=MCU_STP5    ,
+    MMU_PRE_GATE_3=MCU_STP6    ,
+    MMU_PRE_GATE_4=MCU_STP7    ,
+    MMU_PRE_GATE_5=MCU_STP8    ,
+    MMU_PRE_GATE_6=MCU_STP9    ,
+    MMU_PRE_GATE_7=MCU_STP10   ,
+    # MMU_PRE_GATE_8=""          ,
+    # MMU_PRE_GATE_9=""          ,
+    # MMU_PRE_GATE_10=""         ,
+    # MMU_PRE_GATE_11=""         ,
+
+    SPI_SCLK=MCU_SCK , SPI_MOSI=MCU_MOSI , SPI_MISO=MCU_MISO ,
+
+    ## I2C header
+    I2C_SDA=MCU_I2C_SDA  , I2C_SCL=MCU_I2C_SCL  , I2C_GND=<GND>  , I2C_5V=<5V>  ,
+
+    ## SWD header
+    SWD_Reset=<RST> , SWD_PA14=MCU_SWD_PA14 , SWD_GND=<GND> , SWD_PA13=MCU_SWD_PA13 , SWD_3.3V=<3.3V> ,

--- a/user_templates/mcu_defaults/mmu/BTT_MMB_CAN_v2.0.cfg
+++ b/user_templates/mcu_defaults/mmu/BTT_MMB_CAN_v2.0.cfg
@@ -1,0 +1,47 @@
+
+#-----------------------------------------------#
+#### BTT MMB CAN v2.0 board MCU definition ######
+#-----------------------------------------------#
+
+[mcu mmu]
+##--------------------------------------------------------------------
+serial: /dev/serial/by-id/change-me-to-the-correct-mcu-path
+# canbus_uuid: change-me-to-the-correct-canbus-id
+##--------------------------------------------------------------------
+
+# If you want to override the wiring of the BTT MMB CAN board, keep in mind that this
+# board is defined using the "mmu" name. So you should use "pin: mmu:PIN_NAME"
+# in your own overrides.cfg files.
+
+[include config/mcu_definitions/mmu/BTT_MMB_CAN_v2.0.cfg] # Do not remove this line
+[board_pins mmu_mcu]
+mcu: mmu
+aliases:
+    MMU_GEAR_STEP=MCU_M1_STEP  , MMU_GEAR_DIR=MCU_M1_DIR  , MMU_GEAR_ENABLE=MCU_M1_EN  , MMU_GEAR_UART=MCU_M1_UART  ,
+    MMU_SEL_STEP=MCU_M2_STEP   , MMU_SEL_DIR=MCU_M2_DIR   , MMU_SEL_ENABLE=MCU_M2_EN   , MMU_SEL_UART=MCU_M2_UART   ,
+
+    MMU_GEAR_DIAG=MCU_M1_DIAG ,
+    MMU_SEL_DIAG=MCU_M2_DIAG  ,
+
+    MMU_SEL_ENDSTOP=MCU_STP1  ,
+
+    MMU_SERVO=MCU_MOT1        ,
+    MMU_ENCODER=MCU_SENSOR    ,
+    MMU_NEOPIXEL=MCU_RGB      ,
+    # MMU_GATE_SENSOR=MCU_STP3 ,
+
+    MMU_PRE_GATE_0=MCU_STP5   ,
+    MMU_PRE_GATE_1=MCU_STP6   ,
+    MMU_PRE_GATE_2=MCU_STP7   ,
+    MMU_PRE_GATE_3=MCU_STP8   ,
+    MMU_PRE_GATE_4=MCU_STP9   ,
+    MMU_PRE_GATE_5=MCU_STP10  ,
+    MMU_PRE_GATE_6=MCU_STP11  ,
+    MMU_PRE_GATE_7=MCU_STP12  ,
+    # MMU_PRE_GATE_8=""         ,
+    # MMU_PRE_GATE_9=""         ,
+    # MMU_PRE_GATE_10=""        ,
+    # MMU_PRE_GATE_11=""        ,
+
+    ## I2C header
+    I2C_SDA=MCU_I2C_SDA  , I2C_SCL=MCU_I2C_SCL  , I2C_GND=<GND>  , I2C_5V=<5V>  ,


### PR DESCRIPTION
Add manufacturer pin aliases and user MMU templates for BTT MMB CAN v1.1 and v2.0 boards. The v1.1 definition captures the documented M1 enable/STP4 swap, while v2.0 adds the updated motor, endstop, input header, sensor, RGB, servo, and I2C aliases.