### PR TITLE
feat: add Revo PZ virtual z probe profile

### DIFF
--- a/config/hardware/probes/revo_pz.cfg
+++ b/config/hardware/probes/revo_pz.cfg
@@ -1,0 +1,67 @@
+# This probe type is for the E3D Revo PZ Probe used as a virtual Z endstop.
+# It uses the standard Klipper [probe] path, with Klippain handling the shared
+# nozzle-contact temperature guard around G28 Z.
+
+[gcode_macro _USER_VARIABLES]
+variable_probe_type_enabled: "revo_pz"
+variable_probe_uses_virtual_z: True
+variable_probe_uses_nozzle_contact: True
+variable_probe_needs_contact_temp_guard: True
+variable_probe_hook_family: ""
+variable_probe_contact_z_home_mode: "standard_g28"
+variable_probe_contact_auto_calibrate_mode: "none"
+variable_probe_unsupported_contact_action_policy: "warn"
+variable_probe_contact_max_temp: 150
+variable_revo_pz_probing_current: 0.4
+variable_startprint_actions: "bed_soak", "extruder_preheating", "chamber_soak", "clean", "tilt_calib", "z_offset", "bedmesh", "extruder_heating", "purge", "clean", "primeline"
+gcode:
+
+[include ../../../macros/base/homing/homing_override.cfg]
+[include ../../../macros/base/probing/generic_probe.cfg]
+
+[probe]
+pin: !PROBE_INPUT
+x_offset: 0
+y_offset: 0
+z_offset: 0
+speed: 5
+lift_speed: 10
+samples: 2
+samples_result: median
+sample_retract_dist: 3.0
+samples_tolerance: 0.01
+samples_tolerance_retries: 3
+activate_gcode:
+    G4 P200
+    _REVO_PZ_SET_Z_CURRENT
+deactivate_gcode:
+    _REVO_PZ_RESTORE_Z_CURRENT
+
+[gcode_macro _REVO_PZ_SET_Z_CURRENT]
+description: Lower configured Z stepper currents while probing with Revo PZ
+gcode:
+    {% set vars = printer["gcode_macro _USER_VARIABLES"] %}
+    {% set z_driver = vars.z_driver|string %}
+    {% set probing_current = vars.revo_pz_probing_current|float %}
+    {% for stepper in ["stepper_z", "stepper_z1", "stepper_z2", "stepper_z3"] %}
+        {% set section = z_driver ~ " " ~ stepper %}
+        {% if printer.configfile.config[section] is defined %}
+            SET_TMC_CURRENT STEPPER={stepper} CURRENT={probing_current}
+        {% endif %}
+    {% endfor %}
+
+[gcode_macro _REVO_PZ_RESTORE_Z_CURRENT]
+description: Restore configured Z stepper currents after probing with Revo PZ
+gcode:
+    {% set vars = printer["gcode_macro _USER_VARIABLES"] %}
+    {% set z_driver = vars.z_driver|string %}
+    {% for stepper in ["stepper_z", "stepper_z1", "stepper_z2", "stepper_z3"] %}
+        {% set section = z_driver ~ " " ~ stepper %}
+        {% if printer.configfile.config[section] is defined %}
+            {% set run_current = printer.configfile.config[section].run_current|float %}
+            SET_TMC_CURRENT STEPPER={stepper} CURRENT={run_current}
+        {% endif %}
+    {% endfor %}
+
+[stepper_z]
+endstop_pin: probe:z_virtual_endstop

--- a/docs/features/virtual_z_probes.md
+++ b/docs/features/virtual_z_probes.md
@@ -8,11 +8,13 @@ Use one probe include:
 
 ```ini
 [include config/hardware/probes/voron_tap.cfg]
+[include config/hardware/probes/revo_pz.cfg]
 [include config/hardware/probes/beacon_contact.cfg]
 [include config/hardware/probes/cartographer_touch.cfg]
 ```
 
 `voron_tap.cfg` keeps the legacy internal identifier `probe_type_enabled: "vorontap"` for compatibility.
+`revo_pz.cfg` is a standard Klipper `[probe]` profile with `probe_contact_z_home_mode: "standard_g28"`, plus Revo PZ-specific per-probe current handling in `[probe] activate_gcode` and `deactivate_gcode`.
 
 ## Shared Contact Variables
 

--- a/macros/miscs/startup.cfg
+++ b/macros/miscs/startup.cfg
@@ -81,6 +81,8 @@ gcode:
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
     {% set qgl_enabled = printer["gcode_macro _USER_VARIABLES"].qgl_enabled %}
     {% set ztilt_enabled = printer["gcode_macro _USER_VARIABLES"].ztilt_enabled %}
+    {% set probe_uses_virtual_z = printer["gcode_macro _USER_VARIABLES"].probe_uses_virtual_z|default(False) %}
+    {% set probe_uses_nozzle_contact = printer["gcode_macro _USER_VARIABLES"].probe_uses_nozzle_contact|default(False) %}
 
     _INIT_CHECK_VIRTUAL_Z_PROBE
 
@@ -104,18 +106,16 @@ gcode:
     {% endif %}
 
     {% if zcalib_plugin_enabled %}
-        {% if probe_type_enabled == "vorontap" %}
-            { action_raise_error("Voron TAP Probe and Z calibration plugin cannot be used at the same time in Klippain!") }
-        {% elif probe_type_enabled == "beacon_contact" %}
-            { action_raise_error("Beacon Contact Probe and Z calibration plugin cannot be used at the same time in Klippain!") }
+        {% if probe_type_enabled == "none" %}
+            { action_raise_error("You need a probe to use the Z calibration plugin in Klippain!") }
+        {% elif probe_uses_nozzle_contact %}
+            { action_raise_error("Nozzle-contact probes and Z calibration plugin cannot be used at the same time in Klippain!") }
+        {% elif probe_uses_virtual_z %}
+            { action_raise_error("Virtual Z endstop probes are not compatible with the Z calibration plugin!") }
         {% elif probe_type_enabled == "bltouch" %}
             { action_raise_error("BLTouch Probe and Z calibration plugin cannot be used at the same time in Klippain!") }
         {% elif probe_type_enabled == "inductive" %}
             { action_raise_error("Inductive probe and Z calibration plugin cannot be used at the same time in Klippain!") }
-        {% elif probe_type_enabled == "dockable_virtual" or probe_type_enabled == "inductive_virtual" %}
-            { action_raise_error("Virtual Z endstop probes are not compatible with the Z calibration plugin!") }
-        {% elif probe_type_enabled == "none" %}
-            { action_raise_error("You need a probe to use the Z calibration plugin in Klippain!") }
         {% endif %}
     {% endif %}
 

--- a/scripts/validate_probe_framework.py
+++ b/scripts/validate_probe_framework.py
@@ -15,7 +15,7 @@ HOOK_MACROS = {
     "contact_activate": "_PROBE_HOOK_CONTACT_ACTIVATE",
     "contact_deactivate": "_PROBE_HOOK_CONTACT_DEACTIVATE",
 }
-BANNED_NAMES = {"cartographer_survey.cfg"}
+BANNED_NAMES = {"cartographer_survey.cfg", "PZ Probe.cfg"}
 REQUIRED_REPO_PATHS = {
     "README.md": "file",
     "config/machine.cfg": "file",

--- a/user_templates/printer.cfg
+++ b/user_templates/printer.cfg
@@ -106,6 +106,9 @@
 ## Voron TAP, also used naturally as a virtual Z endstop
 # [include config/hardware/probes/voron_tap.cfg]
 
+## E3D Revo PZ Probe, also used naturally as a virtual Z endstop
+# [include config/hardware/probes/revo_pz.cfg]
+
 ## BLTouch probe also used as virtual Z endstop
 # [include config/hardware/probes/bltouch_virtual.cfg]
 


### PR DESCRIPTION
Add support for the E3D Revo PZ Probe used as a virtual Z endstop, based on the virtual Z probe framework.