### PR TITLE
fix: Guard dockable probe cleanup during tilt errors

### DIFF
--- a/macros/base/homing/tilting.cfg
+++ b/macros/base/homing/tilting.cfg
@@ -5,9 +5,10 @@ gcode:
     {% set conf_QGL = printer["gcode_macro _USER_VARIABLES"].qgl_enabled %}
     {% set conf_ztilt = printer["gcode_macro _USER_VARIABLES"].ztilt_enabled %}
     {% set probe_type_enabled = printer["gcode_macro _USER_VARIABLES"].probe_type_enabled %}
+    {% set probe_can_dock = probe_type_enabled == "dockable" or probe_type_enabled == "dockable_virtual" %}
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
 
-    {% if probe_type_enabled == "dockable" %}
+    {% if probe_can_dock %}
         SET_GCODE_VARIABLE MACRO=_PROBE_ON_ERROR_ACTION VARIABLE=probing VALUE=True
     {% endif %}
 
@@ -31,6 +32,6 @@ gcode:
         {% endif %}
     {% endif %}
 
-    {% if probe_type_enabled == "dockable" %}
+    {% if probe_can_dock %}
         SET_GCODE_VARIABLE MACRO=_PROBE_ON_ERROR_ACTION VARIABLE=probing VALUE=False
     {% endif %}

--- a/macros/base/probing/overrides/bed_mesh_calibrate.cfg
+++ b/macros/base/probing/overrides/bed_mesh_calibrate.cfg
@@ -9,6 +9,7 @@ description: Perform Mesh Bed Leveling with klicky automount
 gcode:
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
     {% set probe_type_enabled = printer["gcode_macro _USER_VARIABLES"].probe_type_enabled %}
+    {% set probe_can_dock = probe_type_enabled == "dockable" or probe_type_enabled == "dockable_virtual" %}
 
     {% if verbose %}
         { action_respond_info("Bed Mesh Calibrate") }
@@ -17,13 +18,13 @@ gcode:
 
     ACTIVATE_PROBE
 
-    {% if probe_type_enabled == "dockable" %}
+    {% if probe_can_dock %}
         SET_GCODE_VARIABLE MACRO=_PROBE_ON_ERROR_ACTION VARIABLE=probing VALUE=True
     {% endif %}
 
     _BASE_BED_MESH_CALIBRATE  {% for p in params %}{'%s=%s ' % (p, params[p])}{% endfor %}
 
-    {% if probe_type_enabled == "dockable" %}
+    {% if probe_can_dock %}
         SET_GCODE_VARIABLE MACRO=_PROBE_ON_ERROR_ACTION VARIABLE=probing VALUE=False
     {% endif %}
 

--- a/macros/base/probing/overrides/qgl.cfg
+++ b/macros/base/probing/overrides/qgl.cfg
@@ -9,6 +9,8 @@ description: Conform a moving, twistable gantry to the shape of a stationary bed
 gcode:
     {% set tilting_travel_accel = printer["gcode_macro _USER_VARIABLES"].tilting_travel_accel %}
     {% set status_leds_control_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_control_enabled|default(False) %}
+    {% set probe_type_enabled = printer["gcode_macro _USER_VARIABLES"].probe_type_enabled %}
+    {% set probe_can_dock = probe_type_enabled == "dockable" or probe_type_enabled == "dockable_virtual" %}
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
 
     {% if verbose %}
@@ -23,11 +25,19 @@ gcode:
 
     ACTIVATE_PROBE
 
+    {% if probe_can_dock %}
+        SET_GCODE_VARIABLE MACRO=_PROBE_ON_ERROR_ACTION VARIABLE=probing VALUE=True
+    {% endif %}
+
     # Set the tilting acceleration prior to any movement
     {% set saved_accel = printer.toolhead.max_accel %}
     SET_VELOCITY_LIMIT ACCEL={tilting_travel_accel}
 
     _BASE_QUAD_GANTRY_LEVEL {% for p in params %}{'%s=%s ' % (p, params[p])}{% endfor %}
+
+    {% if probe_can_dock %}
+        SET_GCODE_VARIABLE MACRO=_PROBE_ON_ERROR_ACTION VARIABLE=probing VALUE=False
+    {% endif %}
     
     # Reset acceleration values to what it was before
     SET_VELOCITY_LIMIT ACCEL={saved_accel}

--- a/macros/base/probing/overrides/z_tilt.cfg
+++ b/macros/base/probing/overrides/z_tilt.cfg
@@ -9,6 +9,8 @@ description: Conform a moving bed to the shape of a stationary gantry with docka
 gcode:
     {% set tilting_travel_accel = printer["gcode_macro _USER_VARIABLES"].tilting_travel_accel %}
     {% set status_leds_control_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_control_enabled|default(False) %}
+    {% set probe_type_enabled = printer["gcode_macro _USER_VARIABLES"].probe_type_enabled %}
+    {% set probe_can_dock = probe_type_enabled == "dockable" or probe_type_enabled == "dockable_virtual" %}
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
 
 
@@ -24,11 +26,19 @@ gcode:
 
     ACTIVATE_PROBE
 
+    {% if probe_can_dock %}
+        SET_GCODE_VARIABLE MACRO=_PROBE_ON_ERROR_ACTION VARIABLE=probing VALUE=True
+    {% endif %}
+
     # Set the tilting acceleration prior to any movement
     {% set saved_accel = printer.toolhead.max_accel %}
     SET_VELOCITY_LIMIT ACCEL={tilting_travel_accel}
 
     _BASE_Z_TILT_ADJUST {% for p in params %}{'%s=%s ' % (p, params[p])}{% endfor %}
+
+    {% if probe_can_dock %}
+        SET_GCODE_VARIABLE MACRO=_PROBE_ON_ERROR_ACTION VARIABLE=probing VALUE=False
+    {% endif %}
 
     # Reset acceleration values to what it was before
     SET_VELOCITY_LIMIT ACCEL={saved_accel}

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -140,9 +140,9 @@ variable_probe_move_dock_length: 30
 ##    |         front
 ##    |_ _ _ _ _ _ _ _ _ _ _ _> X
 
-## If there is an error during a tilting procedure (QGL or Z_TILT_ADJUST) or during a BED_MESH_CALIBRATE
-## then automatically dock the probe before stopping all actions. This avoid letting the probe
-## very close to a very hot bed doing nothing as this could destroy the probe microswitch
+## If Klipper runs virtual_sdcard on_error_gcode during QGL, Z_TILT_ADJUST, or BED_MESH_CALIBRATE,
+## then automatically dock the probe before stopping all actions. This avoids leaving the probe
+## close to a hot bed doing nothing, which could destroy the probe microswitch.
 variable_autodock_on_probe_error: True
 
 


### PR DESCRIPTION
Set the probe error guard inside the public QGL and Z_TILT wrappers before running the base calibration commands. This lets virtual_sdcard on_error_gcode dock dockable probes when those commands abort before DEACTIVATE_PROBE can run, and aligns the guard behavior for dockable_virtual probes.