### PR TITLE
feat: Add Orbitool board support

### DIFF
--- a/config/hardware/accelerometers/adxl345_Orbitool_O2S.cfg
+++ b/config/hardware/accelerometers/adxl345_Orbitool_O2S.cfg
@@ -1,0 +1,6 @@
+[include generics/adxl345_hardware_spi1.cfg]
+
+# As it's a toolhead ADXL, we add some default pins overrides from here
+[adxl345]
+cs_pin: toolhead:ADXL_CS
+axes_map: y,z,x

--- a/config/hardware/accelerometers/lis2dw_Orbitool.cfg
+++ b/config/hardware/accelerometers/lis2dw_Orbitool.cfg
@@ -1,0 +1,18 @@
+# This LIS2DW file is dedicated to the built-in accelerometer
+# on Orbitool O2 and Orbitool SO3 boards.
+
+[lis2dw]
+cs_pin: toolhead:LIS2DW
+spi_bus: spi1
+axes_map: y,z,x
+
+[resonance_tester]
+accel_chip: lis2dw
+probe_points:
+    -1,-1,-1
+
+
+# Include the IS calibration macros to unlock them when
+# an accelerometer is installed on the machine
+[include ../../../macros/helpers/resonance_override.cfg]
+[include ../../../scripts/K-ShakeTune/K-SnT_*.cfg]

--- a/config/mcu_definitions/toolhead/Orbitool_O2.cfg
+++ b/config/mcu_definitions/toolhead/Orbitool_O2.cfg
@@ -1,0 +1,20 @@
+# Official documentation https://github.com/RobertLorincz/Orbiter-Toolboards/tree/main/Orbiter%20O2%20Toolboard
+[board_pins toolhead_manufacturer]
+mcu: toolhead
+aliases:
+    MCU_EXT_STEP=PB7 , MCU_EXT_DIR=PB6 , MCU_EXT_EN=PB4 , MCU_EXT_UART=PB5 ,
+
+    MCU_X_STOP=PB0 ,
+    MCU_PROBE=PA15 ,
+    MCU_SERVO=PB3 ,
+
+    MCU_HEAT=PA0 , MCU_TEMP=PA3 , MCU_HOTEND_POWER=PA2 ,
+
+    MCU_PART_FAN=PA10 ,
+    MCU_HOTEND_FAN=PA9 , MCU_HOTEND_FAN_TACH=PA8 ,
+    MCU_TOOL_FAN=PB1 ,
+
+    MCU_RGB=PA1 ,
+    MCU_RUN_LED=PB8 ,
+
+    MCU_LIS2DW_CS=PA4 ,

--- a/config/mcu_definitions/toolhead/Orbitool_O2S.cfg
+++ b/config/mcu_definitions/toolhead/Orbitool_O2S.cfg
@@ -1,0 +1,23 @@
+# Official documentation https://github.com/RobertLorincz/Orbiter-Toolboards/tree/main/Orbiter%20O2S%20Toolboard
+[board_pins toolhead_manufacturer]
+mcu: toolhead
+aliases:
+    MCU_EXT_STEP=PB3 , MCU_EXT_DIR=PB4 , MCU_EXT_EN=PC14 , MCU_EXT_UART=PC13 ,
+
+    MCU_X_STOP=PA2 ,
+
+    MCU_HEAT=PB9 , MCU_TEMP=PA1 , MCU_HOTEND_POWER=PA0 ,
+
+    MCU_PART_FAN_POWER=PA10 , MCU_PART_FAN_PWM=PB0 ,
+    MCU_PART_FAN_EN=PB14 , MCU_PART_FAN_TACH=PA14 ,
+    MCU_HOTEND_FAN=PB15 , MCU_HOTEND_FAN_TACH=PB12 ,
+
+    MCU_RGB=PC15 ,
+    MCU_RUN_LED=PB13 ,
+
+    MCU_FILAMENT_SENSOR=PA8 ,
+    MCU_UNLOAD_BUTTON=PA9 ,
+
+    MCU_I2C_SDA=PB7 , MCU_I2C_SCL=PB6 ,
+
+    MCU_ADXL_CS=PA4 ,

--- a/config/mcu_definitions/toolhead/Orbitool_SO3.cfg
+++ b/config/mcu_definitions/toolhead/Orbitool_SO3.cfg
@@ -1,0 +1,23 @@
+# Official documentation https://github.com/RobertLorincz/Orbiter-Toolboards/tree/main/Orbiter%20SO3%20Toolboard
+[board_pins toolhead_manufacturer]
+mcu: toolhead
+aliases:
+    MCU_EXT_STEP=PB7 , MCU_EXT_DIR=PB6 , MCU_EXT_EN=PB4 , MCU_EXT_UART=PB5 ,
+
+    MCU_X_STOP=PB0 ,
+    MCU_PROBE=PA15 ,
+    MCU_SERVO=PB3 ,
+
+    MCU_HEAT=PA0 , MCU_TEMP=PA2 , MCU_HOTEND_POWER=PA1 ,
+    MCU_BOARD_TEMP=PB1 ,
+
+    MCU_PART_FAN=PA14 ,
+    MCU_HOTEND_FAN=PA8 , MCU_HOTEND_FAN_TACH=PA3 ,
+
+    MCU_RGB=PB8 ,
+    MCU_HOTEND_LED=PA9 ,
+
+    MCU_FILAMENT_SENSOR=PA13 ,
+    MCU_UNLOAD_BUTTON=PA10 ,
+
+    MCU_LIS2DW_CS=PA4 , MCU_LIS2DW_SCK=PA5 , MCU_LIS2DW_MISO=PA6 , MCU_LIS2DW_MOSI=PA7 ,

--- a/user_templates/mcu_defaults/toolhead/Orbitool_O2.cfg
+++ b/user_templates/mcu_defaults/toolhead/Orbitool_O2.cfg
@@ -1,0 +1,75 @@
+
+#----------------------------------------#
+#### Orbitool O2 MCU definition #########
+#----------------------------------------#
+
+[mcu toolhead]
+##--------------------------------------------------------------------
+serial: /dev/serial/by-id/change-me-to-the-correct-mcu-path
+baud: 250000
+restart_method: command
+##--------------------------------------------------------------------
+
+# If you want to override the wiring of the Orbitool O2, keep in mind that this
+# board is defined using the "toolhead" name. So you should use "pin: toolhead:PIN_NAME"
+# in your own overrides.cfg files.
+
+[include config/mcu_definitions/toolhead/Orbitool_O2.cfg] # Do not remove this line
+[board_pins orbitool_o2_mcu]
+mcu: toolhead
+aliases:
+    E_STEP=MCU_EXT_STEP , E_DIR=MCU_EXT_DIR , E_ENABLE=MCU_EXT_EN , E_TMCUART=MCU_EXT_UART ,
+
+    X_STOP=MCU_X_STOP ,
+    PROBE_INPUT=MCU_PROBE ,
+    SERVO_PIN=MCU_SERVO ,
+
+    E_HEATER=MCU_HEAT , E_TEMPERATURE=MCU_TEMP ,
+    HOTEND_POWER=MCU_HOTEND_POWER ,
+
+    PART_FAN=MCU_PART_FAN ,
+    E_FAN=MCU_HOTEND_FAN , E_FAN_TACHO=MCU_HOTEND_FAN_TACH ,
+    TOOL_FAN=MCU_TOOL_FAN ,
+
+    STATUS_NEOPIXEL=MCU_RGB ,
+    STATUS_BOARD=MCU_RUN_LED ,
+
+    LIS2DW=MCU_LIS2DW_CS ,
+
+
+#----------------------------------------#
+#       Orbitool O2 pins remapping       #
+#----------------------------------------#
+
+# These pins overrides are automatically added when you select a USB
+# toolhead MCU during the installation process. They should provide a
+# good base to work with. Feel free to adapt to your board if needed!
+
+[extruder]
+step_pin: toolhead:E_STEP
+dir_pin: toolhead:E_DIR
+enable_pin: !toolhead:E_ENABLE
+heater_pin: toolhead:E_HEATER
+sensor_pin: toolhead:E_TEMPERATURE
+pullup_resistor: 2200
+
+[probe]
+pin: ^toolhead:PROBE_INPUT
+
+[fan]
+pin: toolhead:PART_FAN
+
+[heater_fan hotend_fan]
+pin: !toolhead:E_FAN
+# tachometer_pin: toolhead:E_FAN_TACHO
+
+## Uncomment the following line if not using sensorless homing
+## and having the X endstop plugged to the toolhead MCU
+# [stepper_x]
+# endstop_pin: ^toolhead:X_STOP
+
+[neopixel status_leds]
+pin: toolhead:STATUS_NEOPIXEL
+
+[tmc2209 extruder]
+uart_pin: toolhead:E_TMCUART

--- a/user_templates/mcu_defaults/toolhead/Orbitool_O2S.cfg
+++ b/user_templates/mcu_defaults/toolhead/Orbitool_O2S.cfg
@@ -1,0 +1,81 @@
+
+#-----------------------------------------#
+#### Orbitool O2S MCU definition #########
+#-----------------------------------------#
+
+[mcu toolhead]
+##--------------------------------------------------------------------
+serial: /dev/serial/by-id/change-me-to-the-correct-mcu-path
+restart_method: command
+##--------------------------------------------------------------------
+
+# If you want to override the wiring of the Orbitool O2S, keep in mind that this
+# board is defined using the "toolhead" name. So you should use "pin: toolhead:PIN_NAME"
+# in your own overrides.cfg files.
+
+[include config/mcu_definitions/toolhead/Orbitool_O2S.cfg] # Do not remove this line
+[board_pins orbitool_o2s_mcu]
+mcu: toolhead
+aliases:
+    E_STEP=MCU_EXT_STEP , E_DIR=MCU_EXT_DIR , E_ENABLE=MCU_EXT_EN , E_TMCUART=MCU_EXT_UART ,
+
+    X_STOP=MCU_X_STOP ,
+
+    E_HEATER=MCU_HEAT , E_TEMPERATURE=MCU_TEMP ,
+    HOTEND_POWER=MCU_HOTEND_POWER ,
+
+    PART_FAN=MCU_PART_FAN_POWER , PART_FAN_4W=MCU_PART_FAN_PWM ,
+    PART_FAN_ENABLE=MCU_PART_FAN_EN , PART_FAN_TACHO=MCU_PART_FAN_TACH ,
+    E_FAN=MCU_HOTEND_FAN , E_FAN_TACHO=MCU_HOTEND_FAN_TACH ,
+
+    STATUS_NEOPIXEL=MCU_RGB ,
+    STATUS_BOARD=MCU_RUN_LED ,
+
+    EXTRUDER_SENSOR=MCU_FILAMENT_SENSOR ,
+    UNLOAD_BUTTON=MCU_UNLOAD_BUTTON ,
+
+    I2C_SCL=MCU_I2C_SCL , I2C_SDA=MCU_I2C_SDA ,
+
+    ADXL_CS=MCU_ADXL_CS ,
+
+
+#----------------------------------------#
+#      Orbitool O2S pins remapping       #
+#----------------------------------------#
+
+# These pins overrides are automatically added when you select a USB
+# toolhead MCU during the installation process. They should provide a
+# good base to work with. Feel free to adapt to your board if needed!
+
+[extruder]
+step_pin: toolhead:E_STEP
+dir_pin: !toolhead:E_DIR
+enable_pin: !toolhead:E_ENABLE
+heater_pin: toolhead:E_HEATER
+sensor_pin: toolhead:E_TEMPERATURE
+pullup_resistor: 2200
+
+[fan]
+pin: !toolhead:PART_FAN
+enable_pin: toolhead:PART_FAN_ENABLE
+# For a 4-wire part fan, use pin: toolhead:PART_FAN_4W instead.
+# tachometer_pin: toolhead:PART_FAN_TACHO
+
+[heater_fan hotend_fan]
+pin: !toolhead:E_FAN
+# tachometer_pin: toolhead:E_FAN_TACHO
+
+## Uncomment the following line if not using sensorless homing
+## and having the X endstop plugged to the toolhead MCU
+# [stepper_x]
+# endstop_pin: ^toolhead:X_STOP
+
+[neopixel status_leds]
+pin: toolhead:STATUS_NEOPIXEL
+
+[tmc2240 extruder]
+uart_pin: toolhead:E_TMCUART
+interpolate: false
+run_current: 0.85
+rref: 12000
+stealthchop_threshold: 0

--- a/user_templates/mcu_defaults/toolhead/Orbitool_SO3.cfg
+++ b/user_templates/mcu_defaults/toolhead/Orbitool_SO3.cfg
@@ -1,0 +1,77 @@
+
+#-----------------------------------------#
+#### Orbitool SO3 MCU definition #########
+#-----------------------------------------#
+
+[mcu toolhead]
+##--------------------------------------------------------------------
+serial: /dev/serial/by-id/change-me-to-the-correct-mcu-path
+##--------------------------------------------------------------------
+
+# If you want to override the wiring of the Orbitool SO3, keep in mind that this
+# board is defined using the "toolhead" name. So you should use "pin: toolhead:PIN_NAME"
+# in your own overrides.cfg files.
+
+[include config/mcu_definitions/toolhead/Orbitool_SO3.cfg] # Do not remove this line
+[board_pins orbitool_so3_mcu]
+mcu: toolhead
+aliases:
+    E_STEP=MCU_EXT_STEP , E_DIR=MCU_EXT_DIR , E_ENABLE=MCU_EXT_EN , E_TMCUART=MCU_EXT_UART ,
+
+    X_STOP=MCU_X_STOP ,
+    PROBE_INPUT=MCU_PROBE ,
+    SERVO_PIN=MCU_SERVO ,
+
+    E_HEATER=MCU_HEAT , E_TEMPERATURE=MCU_TEMP ,
+    HOTEND_POWER=MCU_HOTEND_POWER ,
+    TOOLHEAD_TEMPERATURE=MCU_BOARD_TEMP ,
+
+    PART_FAN=MCU_PART_FAN ,
+    E_FAN=MCU_HOTEND_FAN , E_FAN_TACHO=MCU_HOTEND_FAN_TACH ,
+
+    STATUS_NEOPIXEL=MCU_RGB ,
+    HOTEND_LED=MCU_HOTEND_LED ,
+
+    EXTRUDER_SENSOR=MCU_FILAMENT_SENSOR ,
+    UNLOAD_BUTTON=MCU_UNLOAD_BUTTON ,
+
+    LIS2DW=MCU_LIS2DW_CS ,
+    SCK=MCU_LIS2DW_SCK , MISO=MCU_LIS2DW_MISO , MOSI=MCU_LIS2DW_MOSI ,
+
+
+#----------------------------------------#
+#      Orbitool SO3 pins remapping       #
+#----------------------------------------#
+
+# These pins overrides are automatically added when you select a USB
+# toolhead MCU during the installation process. They should provide a
+# good base to work with. Feel free to adapt to your board if needed!
+
+[extruder]
+step_pin: toolhead:E_STEP
+dir_pin: toolhead:E_DIR
+enable_pin: !toolhead:E_ENABLE
+heater_pin: toolhead:E_HEATER
+sensor_pin: toolhead:E_TEMPERATURE
+pullup_resistor: 4700
+
+[probe]
+pin: ^toolhead:PROBE_INPUT
+
+[fan]
+pin: toolhead:PART_FAN
+
+[heater_fan hotend_fan]
+pin: !toolhead:E_FAN
+# tachometer_pin: toolhead:E_FAN_TACHO
+
+## Uncomment the following line if not using sensorless homing
+## and having the X endstop plugged to the toolhead MCU
+# [stepper_x]
+# endstop_pin: ^toolhead:X_STOP
+
+[neopixel status_leds]
+pin: toolhead:STATUS_NEOPIXEL
+
+[tmc2209 extruder]
+uart_pin: toolhead:E_TMCUART

--- a/user_templates/printer.cfg
+++ b/user_templates/printer.cfg
@@ -213,10 +213,12 @@
 # [include config/hardware/accelerometers/adxl345_BTT_SB22xx.cfg] # For ADXL plugged in BTT SB2209 or SB2240 boards
 # [include config/hardware/accelerometers/adxl345_Fysetc_SB_Can_TH.cfg] # For ADXL plugged in Fysetc SB Can TH boards
 # [include config/hardware/accelerometers/adxl345_Fysetc_H36_Combo_V2.cfg] # For built in ADXL sensor on Fysetc H36 Combo V2 boards
+# [include config/hardware/accelerometers/adxl345_Orbitool_O2S.cfg] # For built in ADXL sensor on Orbitool O2S boards
 # [include config/hardware/accelerometers/adxl345_nitehawk.cfg] # For built in ADXL sensor on LDO Nitehawk boards
 
 # [include config/hardware/accelerometers/lis2dw_ebb_gen2.cfg] # For built in LIS2DW sensor on BTT EBB36/42 GEN2 boards
 # [include config/hardware/accelerometers/lis2dw_ebb_sb2209_usb.cfg] # For built in LIS2DW sensor on BTT EBB SB2209 USB boards
+# [include config/hardware/accelerometers/lis2dw_Orbitool.cfg] # For built in LIS2DW sensor on Orbitool O2 or SO3 boards
 # [include config/hardware/accelerometers/lis2dw_sht_v3.x.cfg] # Mellow SHT36 v3
 # [include config/hardware/accelerometers/lis2dw_usb_rp2040_spi1.cfg] # For BTT S2DW V1.0, ...
 


### PR DESCRIPTION
Add MCU pin definitions and installable toolhead templates for Orbitool O2, O2S, and SO3 boards. The templates cover the normal Klippain extruder, fan, endstop, LED, and driver remaps while leaving Orbiter sensor and accelerometer config for user overrides.