### PR TITLE
feat: Add Mellow FLY ERCF v2 board support

### DIFF
--- a/config/mcu_definitions/mmu/Mellow_FLY_ERCF_v2.cfg
+++ b/config/mcu_definitions/mmu/Mellow_FLY_ERCF_v2.cfg
@@ -1,0 +1,24 @@
+[board_pins mmu_manufacturer]
+mcu: mmu
+aliases:
+    MCU_GEAR_STEP=gpio7      , MCU_GEAR_DIR=gpio8     , MCU_GEAR_EN=gpio6     , MCU_GEAR_UART=gpio9     ,
+    MCU_GEAR_DIAG=gpio15     ,
+    MCU_SELECTOR_STEP=gpio4  , MCU_SELECTOR_DIR=gpio3 , MCU_SELECTOR_EN=gpio5 , MCU_SELECTOR_UART=gpio2 ,
+    MCU_SELECTOR_DIAG=gpio20 ,
+
+    MCU_GEAR_ENDSTOP=gpio15     ,
+    MCU_SELECTOR_ENDSTOP=gpio20 ,
+    MCU_ENDSTOP=gpio20          ,
+    MCU_SERVO=gpio21            ,
+    MCU_ENCODER=gpio15          ,
+    MCU_EXTRA=gpio14            ,
+
+    MCU_MISO=gpio16 , MCU_MOSI=gpio18 , MCU_SCK=gpio19 ,
+
+    GND=<GND>       , GND=<GND>       ,
+    3.3V=<3.3V>     , 3.3V=<3.3V>     ,
+    MCU_IO26=gpio26 , MCU_IO10=gpio10 ,
+    MCU_IO27=gpio27 , MCU_IO11=gpio11 ,
+    MCU_IO28=gpio28 , MCU_IO12=gpio12 ,
+    MCU_IO29=gpio29 , MCU_IO24=gpio24 ,
+    MCU_IO25=gpio25 , MCU_IO13=gpio13 ,

--- a/user_templates/mcu_defaults/mmu/Mellow_FLY_ERCF_v2.cfg
+++ b/user_templates/mcu_defaults/mmu/Mellow_FLY_ERCF_v2.cfg
@@ -1,0 +1,38 @@
+
+#---------------------------------------------#
+#### Mellow FLY ERCF v2 MCU definition ########
+#---------------------------------------------#
+
+[mcu mmu]
+##--------------------------------------------------------------------
+serial: /dev/serial/by-id/change-me-to-the-correct-mcu-path
+# canbus_uuid: change-me-to-the-correct-canbus-id
+##--------------------------------------------------------------------
+
+# If you want to override the wiring of the Mellow FLY ERCF v2 board, keep in mind that this
+# board is defined using the "mmu" name. So you should use "pin: mmu:PIN_NAME"
+# in your own overrides.cfg files.
+
+[include config/mcu_definitions/mmu/Mellow_FLY_ERCF_v2.cfg] # Do not remove this line
+[board_pins mmu_mcu]
+mcu: mmu
+aliases:
+    MMU_GEAR_STEP=MCU_GEAR_STEP    , MMU_GEAR_DIR=MCU_GEAR_DIR    , MMU_GEAR_ENABLE=MCU_GEAR_EN    , MMU_GEAR_UART=MCU_GEAR_UART    ,
+    MMU_GEAR_DIAG=MCU_GEAR_DIAG    ,
+    MMU_GEAR_ENDSTOP=MCU_GEAR_ENDSTOP ,
+
+    MMU_SEL_STEP=MCU_SELECTOR_STEP , MMU_SEL_DIR=MCU_SELECTOR_DIR , MMU_SEL_ENABLE=MCU_SELECTOR_EN , MMU_SEL_UART=MCU_SELECTOR_UART ,
+    MMU_SEL_DIAG=MCU_SELECTOR_DIAG ,
+
+    MMU_SEL_ENDSTOP=MCU_SELECTOR_ENDSTOP ,
+    MMU_SERVO=MCU_SERVO                ,
+    MMU_ENCODER=MCU_ENCODER            ,
+    MMU_GATE_SENSOR=MCU_EXTRA          ,
+
+    SPI_SCLK=MCU_SCK , SPI_MOSI=MCU_MOSI , SPI_MISO=MCU_MISO ,
+
+    MMU_PRE_GATE_0=MCU_IO10  , MMU_PRE_GATE_1=MCU_IO26  ,
+    MMU_PRE_GATE_2=MCU_IO11  , MMU_PRE_GATE_3=MCU_IO27  ,
+    MMU_PRE_GATE_4=MCU_IO12  , MMU_PRE_GATE_5=MCU_IO28  ,
+    MMU_PRE_GATE_6=MCU_IO24  , MMU_PRE_GATE_7=MCU_IO29  ,
+    MMU_PRE_GATE_8=MCU_IO13  , MMU_PRE_GATE_9=MCU_IO25  ,


### PR DESCRIPTION
Add manufacturer pin aliases and a user MCU template for the Mellow FLY ERCF v2 MMU board. The template follows the existing Klippain two-level board_pins pattern and exposes the board through the installer alongside the other MMU templates.