### PR TITLE
feat: Add Mellow FLY D5 support

### DIFF
--- a/config/mcu_definitions/main/Mellow_FLY_D5.cfg
+++ b/config/mcu_definitions/main/Mellow_FLY_D5.cfg
@@ -1,0 +1,36 @@
+[board_pins mcu_manufacturer]
+aliases:
+    # Stepper drivers
+    MCU_D0_EN=PC2    , MCU_D0_STEP=PC15  , MCU_D0_DIR=PC14  , MCU_D0_CS=PC13  , MCU_D0_STOP=PB4  ,
+    MCU_D1_EN=PA2    , MCU_D1_STEP=PA1   , MCU_D1_DIR=PA0   , MCU_D1_CS=PC3   , MCU_D1_STOP=PB3  ,
+    MCU_D2_EN=PA6    , MCU_D2_STEP=PA5   , MCU_D2_DIR=PA4   , MCU_D2_CS=PA3   , MCU_D2_STOP=PD2  ,
+    MCU_D3_EN=PB0    , MCU_D3_STEP=PC5   , MCU_D3_DIR=PC4   , MCU_D3_CS=PA7   , MCU_D3_STOP=PB5  ,
+    MCU_D4_EN=PB11   , MCU_D4_STEP=PB10  , MCU_D4_DIR=PB2   , MCU_D4_CS=PB1   ,
+
+    # Heaters
+    MCU_BED_OUT=PC7  ,
+    MCU_HEAT0=PC6    ,
+
+    # Thermistors
+    MCU_BED_TEMP=PC0   ,
+    MCU_HEAT0_TEMP=PC1 ,
+
+    # Fans
+    MCU_FAN0=PC8  , MCU_FAN1=PC9  ,
+
+    # TMC SPI
+    MCU_SPI2_MOSI=PB15 , MCU_SPI2_MISO=PB14 , MCU_SPI2_SCK=PB13 ,
+
+    # Probe
+    MCU_PROBE=PB5 ,
+
+    # EXP1 header
+    EXP1_1=<NC>  , EXP1_3=PC11  , EXP1_5=PC10  , EXP1_7=<NC>  , EXP1_9=<GND> ,
+    EXP1_2=PA15  , EXP1_4=PA14  , EXP1_6=PA13  , EXP1_8=<NC>  , EXP1_10=<5V>,
+
+    # EXP2 header
+    EXP2_1=PB14  , EXP2_3=PC12  , EXP2_5=PB6   , EXP2_7=PB7   , EXP2_9=<GND>,
+    EXP2_2=PB13  , EXP2_4=PB12  , EXP2_6=PB15  , EXP2_8=<RST> , EXP2_10=<NC>,
+
+    # BLTouch
+    MCU_SERVO=PA8 ,

--- a/user_templates/mcu_defaults/main/Mellow_FLY_D5.cfg
+++ b/user_templates/mcu_defaults/main/Mellow_FLY_D5.cfg
@@ -1,0 +1,38 @@
+
+#---------------------------------------#
+#### Mellow FLY D5 MCU definition #######
+#---------------------------------------#
+
+[mcu]
+##--------------------------------------------------------------------
+serial: /dev/serial/by-id/change-me-to-the-correct-mcu-path
+# canbus_uuid: change-me-to-the-correct-canbus-id
+##--------------------------------------------------------------------
+
+[include config/mcu_definitions/main/Mellow_FLY_D5.cfg] # Do not remove this line
+[board_pins fly_d5_mcu]
+mcu: mcu
+aliases:
+    X_STEP=MCU_D0_STEP   , X_DIR=MCU_D0_DIR   , X_ENABLE=MCU_D0_EN   , X_TMCUART=MCU_D0_CS   ,
+    Y_STEP=MCU_D1_STEP   , Y_DIR=MCU_D1_DIR   , Y_ENABLE=MCU_D1_EN   , Y_TMCUART=MCU_D1_CS   ,
+
+    Z_STEP=MCU_D2_STEP   , Z_DIR=MCU_D2_DIR   , Z_ENABLE=MCU_D2_EN   , Z_TMCUART=MCU_D2_CS   ,
+    Z1_STEP=MCU_D4_STEP  , Z1_DIR=MCU_D4_DIR  , Z1_ENABLE=MCU_D4_EN  , Z1_TMCUART=MCU_D4_CS  ,
+
+    E_STEP=MCU_D3_STEP   , E_DIR=MCU_D3_DIR   , E_ENABLE=MCU_D3_EN   , E_TMCUART=MCU_D3_CS   ,
+    E1_STEP=MCU_D4_STEP  , E1_DIR=MCU_D4_DIR  , E1_ENABLE=MCU_D4_EN  , E1_TMCUART=MCU_D4_CS  ,
+
+    DRIVER_SPI_MOSI=MCU_SPI2_MOSI , # Used in case of SPI drivers such as TMC2240 or TMC5160
+    DRIVER_SPI_MISO=MCU_SPI2_MISO , # Used in case of SPI drivers such as TMC2240 or TMC5160
+    DRIVER_SPI_SCK=MCU_SPI2_SCK   , # Used in case of SPI drivers such as TMC2240 or TMC5160
+
+    X_STOP=MCU_D0_STOP , Y_STOP=MCU_D1_STOP , Z_STOP=MCU_D2_STOP ,
+    RUNOUT_SENSOR=MCU_D3_STOP ,
+    PROBE_INPUT=MCU_PROBE     ,
+
+    E_HEATER=MCU_HEAT0      , E_TEMPERATURE=MCU_HEAT0_TEMP ,
+    BED_HEATER=MCU_BED_OUT  , BED_TEMPERATURE=MCU_BED_TEMP ,
+
+    PART_FAN=MCU_FAN0 , E_FAN=MCU_FAN1 ,
+
+    SERVO_PIN=MCU_SERVO ,


### PR DESCRIPTION
Add manufacturer pin aliases and a user MCU template for the Mellow FLY D5 mainboard. The template maps the five driver sockets, heaters, thermistors, fans, SPI helpers, probe, and display headers into Klippain's board_pins convention.