### PR TITLE
Update Cartographer Touch config to current Cartographer naming

### DIFF
--- a/config/hardware/probes/cartographer_touch.cfg
+++ b/config/hardware/probes/cartographer_touch.cfg
@@ -17,14 +17,11 @@ gcode:
 [include ../../../macros/base/probing/generic_probe.cfg]
 [include ../../../macros/base/probing/hooks/cartographer_touch.cfg]
 
-[scanner]
-mcu: scanner
-sensor: cartographer
-sensor_alt: carto
+[cartographer] 
+mcu: cartographer 
 x_offset: 0
 y_offset: 15
-backlash_comp: 0.5
-mesh_runs: 2
+verbose: no # For extra output
 
 [stepper_z]
 endstop_pin: probe:z_virtual_endstop


### PR DESCRIPTION
Current Cartographer documentation uses:

[cartographer]
mcu: cartographer

instead of:

[scanner]
mcu: scanner

The current documentation also removes `backlash_comp` and `mesh_runs`. Users can still define those values in their overrides configuration if needed.

This updates `cartographer_touch.cfg` to match the current Cartographer documentation and prevents Klipper startup/configuration errors when using the latest Cartographer plugin.

https://docs.cartographer3d.com/cartographer-probe/installation-and-setup/software-configuration/klipper-setup