### PR TITLE
Align Cartographer workflow with updated home and print settings

### DIFF
--- a/config/hardware/probes/cartographer_touch.cfg
+++ b/config/hardware/probes/cartographer_touch.cfg
@@ -3,7 +3,7 @@
 
 [gcode_macro _USER_VARIABLES]
 variable_probe_type_enabled: "cartographer_touch"
-variable_startprint_actions: "bed_soak", "extruder_preheating", "chamber_soak", "tilt_calib", "z_offset", "bedmesh", "clean", "contact_z_home", "extruder_heating", "purge", "clean", "primeline"
+variable_startprint_actions: "bed_soak", "extruder_preheating", "chamber_soak", "tilt_calib", "z_offset", "cartographer_touch_home", "bedmesh", "clean", "contact_z_home", "extruder_heating", "purge", "clean", "primeline"
 variable_probe_uses_virtual_z: True
 variable_probe_uses_nozzle_contact: True
 variable_probe_needs_contact_temp_guard: True

--- a/config/hardware/probes/cartographer_touch.cfg
+++ b/config/hardware/probes/cartographer_touch.cfg
@@ -1,5 +1,5 @@
 # This probe type is for Cartographer Survey Touch used as a virtual Z endstop.
-# Install the Cartographer Klipper plugin and configure the scanner MCU before enabling.
+# Install the Cartographer Klipper plugin and configure the cartographer MCU before enabling.
 
 [gcode_macro _USER_VARIABLES]
 variable_probe_type_enabled: "cartographer_touch"
@@ -8,6 +8,10 @@ variable_probe_uses_virtual_z: True
 variable_probe_uses_nozzle_contact: True
 variable_probe_needs_contact_temp_guard: True
 variable_probe_hook_family: ""
+
+# Cartographer Touch uses a virtual Z endstop.
+# Z homing is handled by standard G28.
+# CARTOGRAPHER_TOUCH_HOME is called explicitly when nozzle-height calibration is required.
 variable_probe_contact_z_home_mode: "none"
 variable_probe_contact_auto_calibrate_mode: "none"
 variable_probe_unsupported_contact_action_policy: "warn"

--- a/config/hardware/probes/cartographer_touch.cfg
+++ b/config/hardware/probes/cartographer_touch.cfg
@@ -8,7 +8,7 @@ variable_probe_uses_virtual_z: True
 variable_probe_uses_nozzle_contact: True
 variable_probe_needs_contact_temp_guard: True
 variable_probe_hook_family: "cartographer_touch"
-variable_probe_contact_z_home_mode: "hook"
+variable_probe_contact_z_home_mode: "none"
 variable_probe_contact_auto_calibrate_mode: "none"
 variable_probe_unsupported_contact_action_policy: "warn"
 gcode:

--- a/config/hardware/probes/cartographer_touch.cfg
+++ b/config/hardware/probes/cartographer_touch.cfg
@@ -7,7 +7,7 @@ variable_startprint_actions: "bed_soak", "extruder_preheating", "chamber_soak", 
 variable_probe_uses_virtual_z: True
 variable_probe_uses_nozzle_contact: True
 variable_probe_needs_contact_temp_guard: True
-variable_probe_hook_family: "cartographer_touch"
+variable_probe_hook_family: ""
 variable_probe_contact_z_home_mode: "none"
 variable_probe_contact_auto_calibrate_mode: "none"
 variable_probe_unsupported_contact_action_policy: "warn"

--- a/config/hardware/probes/cartographer_touch.cfg
+++ b/config/hardware/probes/cartographer_touch.cfg
@@ -3,7 +3,7 @@
 
 [gcode_macro _USER_VARIABLES]
 variable_probe_type_enabled: "cartographer_touch"
-variable_startprint_actions: "bed_soak", "extruder_preheating", "chamber_soak", "tilt_calib", "z_offset", "cartographer_touch_home", "bedmesh", "clean", "contact_z_home", "extruder_heating", "purge", "clean", "primeline"
+variable_startprint_actions: "bed_soak", "extruder_preheating", "chamber_soak", "tilt_calib", "z_offset", "cartographer_touch_home", "bedmesh", "clean", "extruder_heating", "purge", "clean", "primeline"
 variable_probe_uses_virtual_z: True
 variable_probe_uses_nozzle_contact: True
 variable_probe_needs_contact_temp_guard: True

--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -178,6 +178,8 @@ gcode:
             _MODULE_CONTACT_AUTO_CALIBRATE
         {% elif action == "beacon_calib" %}
             _MODULE_CONTACT_AUTO_CALIBRATE
+        {% elif action == "cartographer_touch_home" %}
+            _MODULE_CARTOGRAPHER_TOUCH_HOME
         {% elif action == "bedmesh" %}
             _MODULE_BED_MESH
         {% elif action == "primeline" %}
@@ -465,6 +467,16 @@ gcode:
         RESPOND MSG="Contact auto-calibration"
     {% endif %}
     _PROBE_CONTACT_AUTO_CALIBRATE SOURCE=start_print
+
+[gcode_macro _MODULE_CARTOGRAPHER_TOUCH_HOME]
+gcode:
+    {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
+
+    {% if verbose %}
+        RESPOND MSG="Cartographer Touch Home"
+    {% endif %}
+
+    CARTOGRAPHER_TOUCH_HOME
 
 [gcode_macro _MODULE_BED_MESH]
 gcode:

--- a/user_templates/overrides.cfg
+++ b/user_templates/overrides.cfg
@@ -27,9 +27,11 @@
 ## your probe choice (TAP, Dockable, Inductive). If you still want to change it, uncomment the next 3 lines
 ## to define `variable_startprint_actions`. You can use any number of actions, and you can duplicate actions if needed.
 ## Available actions: "bed_soak", "extruder_preheating", "chamber_soak", "extruder_heating", "tilt_calib",
-##                    "z_offset", "beacon_calib", "bedmesh", "purge", "clean", "primeline"
+##                    "z_offset", "cartographer_touch_home", "beacon_calib", "bedmesh", "purge", "clean", "primeline"
 ## You can add custom actions with a matching `_START_PRINT_ACTION_<NAME>` macro. Example:
 ##   variable_startprint_actions: "bed_soak", "my_start_action", "bedmesh", "primeline"
+## Example for Cartographer Touch:
+##   variable_startprint_actions: "bed_soak", "tilt_calib", "cartographer_touch_home", "bedmesh", "primeline"
 ##   [gcode_macro _START_PRINT_ACTION_MY_START_ACTION]
 ##   gcode:
 ##     ## Your custom START_PRINT G-code here

--- a/user_templates/printer.cfg
+++ b/user_templates/printer.cfg
@@ -116,7 +116,7 @@
 # [include config/hardware/probes/beacon_virtual.cfg]   # Uncomment if Beacon firmware version is 1.x
 # [include config/hardware/probes/beacon_contact.cfg]   # Uncomment if Beacon firmware version is 2.x or higher
 
-## Cartographer Survey Touch probe also used as virtual Z endstop. Install the Cartographer plugin and configure the cartographer MCU first.
+## Cartographer Survey Touch probe also be used as virtual Z endstop. Install the Cartographer plugin and configure the cartographer MCU first.
 # [include config/hardware/probes/cartographer_touch.cfg]
 # ----------------------------------------------------------------------------------------
 

--- a/user_templates/printer.cfg
+++ b/user_templates/printer.cfg
@@ -116,7 +116,7 @@
 # [include config/hardware/probes/beacon_virtual.cfg]   # Uncomment if Beacon firmware version is 1.x
 # [include config/hardware/probes/beacon_contact.cfg]   # Uncomment if Beacon firmware version is 2.x or higher
 
-## Cartographer Survey Touch probe also used as virtual Z endstop. Install the Cartographer plugin and configure the scanner MCU first.
+## Cartographer Survey Touch probe also used as virtual Z endstop. Install the Cartographer plugin and configure the cartographer MCU first.
 # [include config/hardware/probes/cartographer_touch.cfg]
 # ----------------------------------------------------------------------------------------
 


### PR DESCRIPTION
- Remove hooks for cartographer and define it like a virtual z probe (like beacon virtual).
- Create a module and gcode macro for Cartographer_touch_home. (it's all it needs for touch). And modify start_print sequence according to cartographer documentation.
- Syntax/typo fixes.