### PR TITLE
fix: BTT EBB Gen2 fan aliases

### DIFF
--- a/user_templates/mcu_defaults/toolhead/BTT_EBB36_GEN2_v1.0.cfg
+++ b/user_templates/mcu_defaults/toolhead/BTT_EBB36_GEN2_v1.0.cfg
@@ -25,8 +25,8 @@ aliases:
     E_HEATER=MCU_HOTEND0 , E_TEMPERATURE=MCU_TH0 ,
     TOOLHEAD_TEMPERATURE=MCU_BOARD_TEMP ,
 
-    PART_FAN=MCU_FAN1 , E_FAN=MCU_FAN2 ,
-    AUX_FAN=MCU_FAN3 , AUX_FAN_TACH=MCU_FAN3_TACH ,
+    PART_FAN=MCU_FAN1 , E_FAN=MCU_FAN3 , E_FAN_TACHO=MCU_FAN3_TACH ,
+    AUX_FAN=MCU_FAN2 ,
 
     STATUS_NEOPIXEL=MCU_RGB ,
 
@@ -54,6 +54,14 @@ pin: ^toolhead:PROBE_INPUT
 
 [fan]
 pin: toolhead:PART_FAN
+
+## To use PART_FAN and AUX_FAN together as the part cooling fan,
+## replace the [fan] section above with the following:
+# [multi_pin dual_part_fan]
+# pins: toolhead:PART_FAN,toolhead:AUX_FAN
+#
+# [fan]
+# pin: multi_pin:dual_part_fan
 
 [heater_fan hotend_fan]
 pin: toolhead:E_FAN

--- a/user_templates/mcu_defaults/toolhead/BTT_EBB42_GEN2_v1.0.cfg
+++ b/user_templates/mcu_defaults/toolhead/BTT_EBB42_GEN2_v1.0.cfg
@@ -25,8 +25,8 @@ aliases:
     E_HEATER=MCU_HOTEND0 , E_TEMPERATURE=MCU_TH0 ,
     TOOLHEAD_TEMPERATURE=MCU_BOARD_TEMP ,
 
-    PART_FAN=MCU_FAN1 , E_FAN=MCU_FAN2 ,
-    AUX_FAN=MCU_FAN3 , AUX_FAN_TACH=MCU_FAN3_TACH ,
+    PART_FAN=MCU_FAN1 , E_FAN=MCU_FAN3 , E_FAN_TACHO=MCU_FAN3_TACH ,
+    AUX_FAN=MCU_FAN2 ,
 
     STATUS_NEOPIXEL=MCU_RGB ,
 
@@ -54,6 +54,14 @@ pin: ^toolhead:PROBE_INPUT
 
 [fan]
 pin: toolhead:PART_FAN
+
+## To use PART_FAN and AUX_FAN together as the part cooling fan,
+## replace the [fan] section above with the following:
+# [multi_pin dual_part_fan]
+# pins: toolhead:PART_FAN,toolhead:AUX_FAN
+#
+# [fan]
+# pin: multi_pin:dual_part_fan
 
 [heater_fan hotend_fan]
 pin: toolhead:E_FAN


### PR DESCRIPTION
- Pinout declared the tachometer fan port as AUX fan instead of extruder/hotend
- Also add an example of how to use PART + AUX fans for part cooling