### PR TITLE
feat: Support minimal chamber temperature from slicer

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -44,6 +44,7 @@ Klippain will work out of the box with most slicers on the market and your profi
 
 In addition, there are a few other optional parameters that are supported in Klippain (they must be added on the same line after the first parameters):
   - `CHAMBER=[chamber_temperature]` to set a target heatsoak temperature during the START_PRINT sequence.
+  - `MINIMAL_CHAMBER=[chamber_minimal_temperature]` to start the print as soon as the chamber reaches this minimal temperature instead of waiting for the full `CHAMBER` setpoint. `CHAMBER` is still used as the setpoint (raised to at least this value) for custom macros such as bed fans.
   - `TOTAL_LAYER=[total_layer_count]` to be able to set the PRINT_STATS_INFOS in Klipper. If you use this, you will also need to add the corresponding `SET_PRINT_STATS_INFO CURRENT_LAYER={layer_num}` to your slicer custom layer change gcode.
   - `TOOLS_USED=!referenced_tools!` *(only for MMU users)* is highly recommended to check only the used tools with the HappyHare [Moonraker gcode preprocessor](https://github.com/moggieuk/Happy-Hare/blob/main/doc/gcode_preprocessing.md).
   - `CHECK_GATES=0` or `1` *(only for MMU users)* that will override the corresponding variable defined in Klippain `variables.cfg` for this specific print.

--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -5,6 +5,7 @@ variable_extruder_temp: 0
 variable_z_adjust: 0
 variable_soak: 0
 variable_chamber_temp: 0
+variable_minimal_chamber_temp: 0
 variable_chamber_maxtime: 0
 variable_initial_tool: 0
 variable_check_gates: 0
@@ -27,6 +28,8 @@ gcode:
     {% set Z_ADJUST = params.Z_ADJUST|default(0)|float %}  # Optionnal Z adjustement from the slicer profile (ex. use it if you have textured vs smooth slicer profiles) 
     {% set SOAK = params.SOAK|default(printer["gcode_macro _USER_VARIABLES"].print_default_soak)|int %} # Heatsoak time of the bed in minutes
     {% set CHAMBER_TEMP = params.CHAMBER|default(printer["gcode_macro _USER_VARIABLES"].print_default_chamber_temp)|int %} # Chamber temperature setpoint
+    {% set MINIMAL_CHAMBER_TEMP = params.MINIMAL_CHAMBER|default(0)|int %} # Minimal chamber temperature to wait for during the heatsoak (0 to use the setpoint instead)
+    {% set CHAMBER_TEMP = [CHAMBER_TEMP, MINIMAL_CHAMBER_TEMP]|max %} # The chamber setpoint can never be below the minimal temperature we wait for
     {% set CHAMBER_MAXTIME = params.CHAMBER_MAXTIME|default(printer["gcode_macro _USER_VARIABLES"].print_default_chamber_max_heating_time)|int %} # Chamber heatsoak timeout in minutes
     {% set INITIAL_TOOL = params.INITIAL_TOOL|default(0)|int %} # Initial tool (for the MMU/ERCF initialization)
     {% set MATERIAL = params.MATERIAL|default(printer["gcode_macro _USER_VARIABLES"].print_default_material)|string %} # Material type set in the slicer
@@ -42,6 +45,7 @@ gcode:
     SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=extruder_temp VALUE={EXTRUDER_TEMP}
     SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=soak VALUE={SOAK}
     SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=chamber_temp VALUE={CHAMBER_TEMP}
+    SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=minimal_chamber_temp VALUE={MINIMAL_CHAMBER_TEMP}
     SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=chamber_maxtime VALUE={CHAMBER_MAXTIME}
     SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=initial_tool VALUE={INITIAL_TOOL}
     SET_GCODE_VARIABLE MACRO=START_PRINT VARIABLE=check_gates VALUE={CHECK_GATES}
@@ -306,8 +310,11 @@ gcode:
 gcode:
     # ----- CHAMBER HEATSOAK ----------------------------------
     # If a setpoint is defined and a sensor available, then we wait to reach the chamber temperature (with a timeout in case it's winter...)
+    # If a minimal chamber temperature is defined, we wait for it instead of the setpoint to allow starting the print earlier
     # If there is one, the recirculating filter is also be powered on from the previous step and kept like that to act as bed fans
     {% set CHAMBER_TEMP = printer["gcode_macro START_PRINT"].chamber_temp %}
+    {% set MINIMAL_CHAMBER_TEMP = printer["gcode_macro START_PRINT"].minimal_chamber_temp %}
+    {% set CHAMBER_TEMP = MINIMAL_CHAMBER_TEMP if MINIMAL_CHAMBER_TEMP > 0 else CHAMBER_TEMP %}
     {% set CHAMBER_MAXTIME = printer["gcode_macro START_PRINT"].chamber_maxtime %}
     {% set CHAMBER_TEMP_TOLERANCE = printer["gcode_macro _USER_VARIABLES"].print_default_chamber_temp_tolerance|default(0)|float|abs %}
 


### PR DESCRIPTION
PrusaSlicer and OrcaSlicer expose a per-filament chamber_minimal_temperature in
addition to the nominal chamber_temperature. Add a MINIMAL_CHAMBER parameter to
START_PRINT so the chamber heatsoak can gate on that minimal value and start the
print earlier, while CHAMBER keeps its meaning as the nominal setpoint read by
custom user macros (chamber heaters, bed fans).

The stored chamber_temp is guarded to max(CHAMBER, MINIMAL_CHAMBER) so a heater
target can never sit below the temperature the heatsoak waits for. Nominal-only
calls behave exactly as before.
