### PR TITLE
fix: Skip purge bucket move when position is unset

### DIFF
--- a/macros/helpers/nozzle_cleaning.cfg
+++ b/macros/helpers/nozzle_cleaning.cfg
@@ -148,9 +148,10 @@ gcode:
     {% set purge_and_brush_enabled = printer["gcode_macro _USER_VARIABLES"].purge_and_brush_enabled %}
     {% set purgeclean_servo_enabled = printer["gcode_macro _USER_VARIABLES"].purgeclean_servo_enabled %}
     {% set Px, Py, Pz = printer["gcode_macro _USER_VARIABLES"].purge_bucket_xyz|map('float') %}
+    {% set purge_bucket_configured = not (Px == -1 and Py == -1 and Pz == -1) %}
 
     # Move to purge zone only if it's available, else just purge where the toolhead is
-    {% if purge_and_brush_enabled %}
+    {% if purge_and_brush_enabled and purge_bucket_configured %}
         SAVE_GCODE_STATE NAME=CONDITIONAL_MOVE_TO_PURGE_BUCKET_STATE
         G90
 


### PR DESCRIPTION
## Summary
- `variables.cfg` documents `-1, -1, -1` as the safe sentinel for `purge_bucket_xyz` when a machine has no purge bucket, but `_CONDITIONAL_MOVE_TO_PURGE_BUCKET` only gated the move on `purge_and_brush_enabled` and never checked the sentinel
- Anyone with `purge_and_brush_enabled: True` and a brush but no purge bucket (the documented use case) hit a "move out of range" error from `CLEAN_NOZZLE`/`PURGE` instead of the intended "purge where the toolhead is" fallback
- Adds the missing sentinel check so the existing fallback comment actually matches the code

Fixes #737

## Test plan
- [ ] Set `purge_and_brush_enabled: True`, `purge_bucket_xyz: -1, -1, -1`, `brush_xyz` to a valid position, and confirm `CLEAN_NOZZLE`/`PURGE` no longer error and purge at the current toolhead position
- [ ] Set a valid `purge_bucket_xyz` and confirm the toolhead still moves to the purge bucket as before