### PR TITLE
feat: Warn at startup if park position is not configured

### DIFF
--- a/macros/miscs/startup.cfg
+++ b/macros/miscs/startup.cfg
@@ -30,6 +30,9 @@ gcode:
         { action_raise_error("Klippain need to have an extruder defined to work properly. Check your printer.cfg includes!") }
     {% endif %}
 
+    # Check that the park position has been customized for this machine
+    _INIT_CHECK_PARK_POSITION
+
     # Check the probe configuration and compatibility with current includes
     _INIT_CHECKPROBECONF
 
@@ -80,6 +83,14 @@ gcode:
                 STATUS_LEDS COLOR="OFF"
             {% endif %}
         {% endif %}
+    {% endif %}
+
+
+[gcode_macro _INIT_CHECK_PARK_POSITION]
+gcode:
+    {% set Px, Py = printer["gcode_macro _USER_VARIABLES"].park_position_xy|map('float') %}
+    {% if Px == -1 and Py == -1 %}
+        { action_raise_error("variable_park_position_xy is still set to its default -1, -1 placeholder in your variables.cfg. Set it to a safe park position for your machine before starting a print.") }
     {% endif %}
 
 


### PR DESCRIPTION
## Summary
- `variable_park_position_xy` defaults to `-1, -1` on purpose, to force machine owners to set a real park position rather than silently using an unsafe default
- Previously that only surfaced as a "move out of range" error from `PARK` the first time it ran, often mid-print
- Adds `_INIT_CHECK_PARK_POSITION`, following the existing `_INIT_CHECK_*` pattern in `macros/miscs/startup.cfg`, so unconfigured machines fail loudly at startup instead of during `PARK`

Addresses #285, per the approach [Frix-x proposed](https://github.com/Frix-x/klippain/issues/285#issuecomment-1685968649)

## Test plan
- [ ] Leave `variable_park_position_xy: -1, -1` and confirm Klippain startup now raises a clear error instead of succeeding silently
- [ ] Set a real park position and confirm startup succeeds and `PARK` behaves as before