### PR TITLE
feat: Allow disabling per-material print settings

### DIFF
--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -77,8 +77,11 @@ gcode:
     {% set filament_sensor_enabled = filament_sensor_available %}
     {% set part_fan_tach_enabled = printer["gcode_macro _USER_VARIABLES"].part_fan_tach_enabled|default(False) %}
     {% set hotend_fan_tach_enabled = printer["gcode_macro _USER_VARIABLES"].hotend_fan_tach_enabled|default(False) %}
+    {% set material_profiles_enabled = printer["gcode_macro _USER_VARIABLES"].material_profiles_enabled|default(True) %}
 
-    {% if MATERIAL not in printer["gcode_macro _USER_VARIABLES"].material_parameters %}
+    {% if not material_profiles_enabled %}
+        RESPOND MSG="Material profile handling is disabled, using slicer-provided settings"
+    {% elif MATERIAL not in printer["gcode_macro _USER_VARIABLES"].material_parameters %}
         RESPOND MSG="Material '{MATERIAL}' is unknown!"
         { action_raise_error("Add this new material to your material_parameters variable!") }
     {% else %}
@@ -134,10 +137,12 @@ gcode:
     M83
 
     # Material parameters
-    {% if firmware_retraction_enabled %}
-        SET_RETRACTION RETRACT_LENGTH={material.retract_length} RETRACT_SPEED={material.retract_speed} UNRETRACT_EXTRA_LENGTH={material.unretract_extra_length} UNRETRACT_SPEED={material.unretract_speed}
+    {% if material_profiles_enabled %}
+        {% if firmware_retraction_enabled %}
+            SET_RETRACTION RETRACT_LENGTH={material.retract_length} RETRACT_SPEED={material.retract_speed} UNRETRACT_EXTRA_LENGTH={material.unretract_extra_length} UNRETRACT_SPEED={material.unretract_speed}
+        {% endif %}
+        SET_PRESSURE_ADVANCE ADVANCE={material.pressure_advance}
     {% endif %}
-    SET_PRESSURE_ADVANCE ADVANCE={material.pressure_advance}
 
     # Homing before START_PRINT movements and actions
     {% if force_homing_in_start_print %}
@@ -220,9 +225,11 @@ gcode:
     SET_GCODE_OFFSET Z_ADJUST={Z_ADJUST} MOVE=1
 
     # Final material parameters
-    SET_GCODE_OFFSET Z_ADJUST={material.additional_z_offset} MOVE=1
-    {% if filter_enabled %}
-        START_FILTER SPEED={material.filter_speed / 100}
+    {% if material_profiles_enabled %}
+        SET_GCODE_OFFSET Z_ADJUST={material.additional_z_offset} MOVE=1
+        {% if filter_enabled %}
+            START_FILTER SPEED={material.filter_speed / 100}
+        {% endif %}
     {% endif %}
 
     {% if filament_sensor_available %}

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -186,6 +186,11 @@ variable_print_default_chamber_temp_tolerance: 0.0
 variable_print_default_soak: 8
 variable_print_default_material: "XXX"
 
+## Set to False to skip Klippain's per-material print settings (retraction, pressure advance,
+## Z offset, filter speed, filament sensor toggle) entirely. Useful for ERCF/MMU prints that mix
+## materials, or if you'd rather let the slicer's own per-material G-code control these values.
+variable_material_profiles_enabled: True
+
 ## Material configuration parameters applied during START_PRINT by using the slicer MATERIAL variable
 ## FYI, retract paramaters are used only if firmware retraction is enabled, filter speed (in %) is used if
 ## there is a filter installed on the machine, filament sensor is on or off if installed, etc...


### PR DESCRIPTION
## Summary
- `START_PRINT` requires a `MATERIAL` param resolvable against `variable_material_parameters`, and hard-errors on an unknown material. Once resolved, it unconditionally applies `material.retract_length/speed`, `material.pressure_advance`, `material.additional_z_offset`, and `material.filter_speed` — with no way to opt out
- That's a problem for ERCF/MMU prints that mix multiple materials in a single job (a single `MATERIAL` value doesn't apply), and for users who'd rather have their slicer's own per-material G-code (M900, retraction, Z offset) be authoritative instead of Klippain overriding it after `START_PRINT`
- Adds `variable_material_profiles_enabled` (default `True`, no behavior change for existing setups). When `False`, `START_PRINT` skips the material lookup/validation entirely and leaves retraction, pressure advance, Z offset, and filter speed untouched — the filter still starts (at its default speed) if enabled

Closes #211

## Test plan
- [ ] With the default (`True`), confirm `START_PRINT` behaves exactly as before: unknown `MATERIAL` still errors, known materials still apply their retraction/pressure-advance/Z-offset/filter settings
- [ ] With `variable_material_profiles_enabled: False`, confirm `START_PRINT` completes with an unset/unknown `MATERIAL` and does not touch retraction, pressure advance, or Z offset