### PR TITLE
fix: Restore extruder pressure after the prime line retract

### DIFF
--- a/macros/helpers/prime_line.cfg
+++ b/macros/helpers/prime_line.cfg
@@ -138,7 +138,14 @@ gcode:
     G91
     G1 X2 Y2 F{St}
     G90
-    
+
+    # Restore the pressure removed by the retract above. Without this, the slicer's own
+    # retract/unretract pair around the first layer change is left compensating for this
+    # extra unmatched retraction, under-extruding the start of the first perimeter.
+    G92 E0
+    G1 E0.2 F2100
+    G92 E0
+
     # Flushing Klipper's buffer to ensure the primeline sequence is done before continuing
     M400
 


### PR DESCRIPTION
## Summary
- `PRIMELINE` retracts 0.2mm before the Z-hop and escape move (`macros/helpers/prime_line.cfg`), but never un-retracts it
- That leftover retraction is still outstanding when the slicer's own retract/unretract pair around the first layer change (`BEFORE_LAYER_CHANGE`/`AFTER_LAYER_CHANGE`) runs. The slicer's unretract only cancels its own retract, so the print starts under-primed by the extra 0.2mm, under-extruding the start of the first perimeter — worst on small first-layer features that can end up not sticking and turning into a blob
- Adds a matching 0.2mm unretract after the escape move, restoring the extruder to the same pressure state it was in right after the prime line was drawn, before handing off to the slicer's gcode

Closes #670

## Test plan
- [ ] Print a part with a small first-layer feature (e.g. embossed text) near the prime line and confirm it's no longer under-extruded/missing at the start