### PR TITLE
fix: caselight status led effects toggle

### DIFF
--- a/config/hardware/lights/neopixel_caselight.cfg
+++ b/config/hardware/lights/neopixel_caselight.cfg
@@ -3,7 +3,7 @@
 [gcode_macro _USER_VARIABLES]
 variable_status_leds_control_enabled = True
 variable_status_leds_caselight_enabled = True
-variable_status_leds_effects_enabled = False
+variable_status_leds_effects_caselight_enabled = False
 variable_status_leds_caselight_led_name: "caselight"
 gcode:
 

--- a/config/hardware/lights/neopixel_caselight_effects.cfg
+++ b/config/hardware/lights/neopixel_caselight_effects.cfg
@@ -4,7 +4,7 @@
 [gcode_macro _USER_VARIABLES]
 variable_status_leds_control_enabled = True
 variable_status_leds_caselight_enabled = True
-variable_status_leds_effects_enabled = True
+variable_status_leds_effects_caselight_enabled = True
 variable_status_leds_caselight_led_name: "caselight"
 gcode:
 

--- a/macros/hardware_functions/status_leds.cfg
+++ b/macros/hardware_functions/status_leds.cfg
@@ -212,7 +212,7 @@ gcode:
     {% endif %}
 
     {% if printer["gcode_macro _USER_VARIABLES"].status_leds_caselight_enabled%}
-        {% if printer["gcode_macro _USER_VARIABLES"].status_leds_effects_enabled == False %}
+        {% if printer["gcode_macro _USER_VARIABLES"].status_leds_effects_caselight_enabled|default(False) == False %}
             _SET_ALLLEDS_BY_NAME LEDS="caselight" COLOR={status_color[color].caselight} TRANSMIT=1
         {% else %}
             SET_LED_EFFECT EFFECT={"cl_" + status_color[color].caselight} REPLACE=1 FADETIME=0.5


### PR DESCRIPTION
Summary

- variable_status_leds_effects_enabled was declared identically in both the status-leds hardware files (status_leds.cfg, status_leds_effects.cfg, status_leds_rainbow_barf.cfg, status_leds_rainbow_barf_effects.cfg) and the caselight ones (neopixel_caselight.cfg,
neopixel_caselight_effects.cfg)
- Including one file from each group at the same time (stealthburner-style status LEDs + a separate caselight) meant whichever was included last in printer.cfg silently overwrote the other's value for that shared variable — and there was no way to have status LEDs use effects while the
caselight stays a plain color, or vice versa
- Gives caselight its own variable_status_leds_effects_caselight_enabled, matching the existing status_leds_enabled/status_leds_caselight_enabled split already used for the "is this fixture on" toggle. The status_leds*.cfg files are unchanged — variable_status_leds_effects_enabled now
unambiguously applies to the logo/nozzle status LEDs only
- STATUS_LEDS's caselight branch (macros/hardware_functions/status_leds.cfg) now reads the new variable, with a |default(False) fallback for configs that don't declare it

Closes #680, and resolves the same root cause reported (but not fixed) in #537.
