### PR TITLE
fix: Configure Mellow SB2040 Pro extruder TMC2240 for SPI, not UART

### DIFF
--- a/config/mcu_definitions/toolhead/Mellow_SB2040_Pro.cfg
+++ b/config/mcu_definitions/toolhead/Mellow_SB2040_Pro.cfg
@@ -1,7 +1,7 @@
 [board_pins toolhead_manufacturer]
 mcu: toolhead
 aliases:
-    MCU_EMOT_EN=gpio7   , MCU_EMOT_STEP=gpio9 , MCU_EMOT_DIR=gpio10 , MCU_EMOT_CS=gpio8 ,
+    MCU_EMOT_EN=gpio7   , MCU_EMOT_STEP=gpio9 , MCU_EMOT_DIR=gpio10 , MCU_EMOT_CS=gpio11 ,
 
     MCU_5V_ENDSTOP=gpio28 ,
     MCU_ENDSTOP=gpio29    ,

--- a/user_templates/mcu_defaults/toolhead/Mellow_SB2040_Pro.cfg
+++ b/user_templates/mcu_defaults/toolhead/Mellow_SB2040_Pro.cfg
@@ -16,7 +16,7 @@ canbus_uuid: change-me-to-the-correct-canbus-id
 [board_pins sb2040_mcu]
 mcu: toolhead
 aliases:
-    E_STEP=MCU_EMOT_STEP , E_DIR=MCU_EMOT_DIR , E_ENABLE=MCU_EMOT_EN , E_TMCUART=MCU_EMOT_CS ,
+    E_STEP=MCU_EMOT_STEP , E_DIR=MCU_EMOT_DIR , E_ENABLE=MCU_EMOT_EN , E_TMCCS=MCU_EMOT_CS ,
 
     X_STOP=MCU_ENDSTOP             ,
     PROBE_INPUT=MCU_HV_ENDSTOP     ,
@@ -72,6 +72,11 @@ pin: toolhead:E_FAN
 [neopixel status_leds]
 pin: toolhead:STATUS_NEOPIXEL
 
+# The extruder driver is wired for SPI on this board and shares its bus with the
+# ADXL345 accelerometer (gpio0/2/3). Don't be surprised by the pin names below.
 [tmc2240 extruder]
-uart_pin: toolhead:E_TMCUART
+cs_pin: toolhead:E_TMCCS
+spi_software_sclk_pin: toolhead:ADXL_SCLK
+spi_software_mosi_pin: toolhead:ADXL_MOSI
+spi_software_miso_pin: toolhead:ADXL_MISO
 


### PR DESCRIPTION
The extruder driver on this board is wired for SPI, sharing its bus with the onboard ADXL345 (gpio0/2/3), per Mellow's own reference config (Mellow-3D/klipper-docs, board/fly_sb2040_pro/cfg.md: cs_pin: gpio11 + shared software SPI bus). The template configured it as uart_pin instead, on gpio8, which isn't even the right pin for that signal.

Since the driver was never listening for UART frames on any pin, no gpio number would have fixed the "Unable to read tmc uart 'extruder' register IFCNT" error - confirmed by a reporter in the issue who corrected the pin to the right number (gpio11) and still hit the same error, because the communication mode itself was wrong, not just the pin.

Switch the extruder driver to cs_pin + the shared ADXL SPI bus pins, matching both the vendor's own config and the same pattern already used by BTT_SB2240_v1.0.cfg for its shared-SPI-bus TMC2240.

Closes #681