### PR TITLE
fix: Clear stale contact guard left by interrupted operations

### DIFF
--- a/config/machine.cfg
+++ b/config/machine.cfg
@@ -7,6 +7,9 @@ on_error_gcode:
     {% if printer["gcode_macro _USER_VARIABLES"].probe_type_enabled == "dockable" or printer["gcode_macro _USER_VARIABLES"].probe_type_enabled == "dockable_virtual" %}
         _PROBE_ON_ERROR_ACTION
     {% endif %}
+    {% if printer["gcode_macro _USER_VARIABLES"].probe_needs_contact_temp_guard|default(False) %}
+        _PROBE_RESET_CONTACT_GUARD
+    {% endif %}
 
     # Park only if printer is homed
     {% if "xyz" in printer.toolhead.homed_axes %}

--- a/docs/features/virtual_z_probes.md
+++ b/docs/features/virtual_z_probes.md
@@ -64,6 +64,14 @@ contact_z_home fails closed when the active probe profile does not support hook-
 variable_probe_unsupported_contact_action_policy: "error"
 ```
 
+## Guard Recovery
+
+If a guarded contact operation is interrupted (print error, cancel, emergency stop), the temperature guard state is cleared automatically the next time it matters: `START_PRINT`, `CANCEL_PRINT`, `END_PRINT`, the `virtual_sdcard` error handler, and `ACTIVATE_PROBE` all discard a stale guard silently. These resets never move the toolhead and never change the extruder target; `START_PRINT` re-establishes its temperatures itself.
+
+`_PROBE_RECOVER_CONTACT_GUARD` remains available for manual inspection. Run it to see the saved extruder target, then run `_PROBE_RECOVER_CONTACT_GUARD CONFIRM=1` to restore that target once the nozzle is clear of the bed.
+
+With Klippain verbose mode enabled, guard enter, exit, and reset events are reported in the console to help diagnose probing issues.
+
 ## Developer Notes
 
 To add a new virtual-Z contact probe, create a concrete profile in `config/hardware/probes/`. Set capability variables and include a hook file only when the probe needs product-specific commands.

--- a/macros/base/cancel_print.cfg
+++ b/macros/base/cancel_print.cfg
@@ -31,6 +31,10 @@ gcode:
         G1 E-{retract_length} F2100
     {% endif %}
 
+    # Clear any contact probe guard left over from an interrupted probing operation.
+    # The heater targets are set just below, so the guard's saved target is not restored
+    _PROBE_RESET_CONTACT_GUARD
+
     {% if turn_off_heaters_in_end_print %}
         TURN_OFF_HEATERS
     {% else %}

--- a/macros/base/end_print.cfg
+++ b/macros/base/end_print.cfg
@@ -22,6 +22,9 @@ gcode:
 
     M400
 
+    # Clear any contact probe guard left over from an interrupted probing operation
+    _PROBE_RESET_CONTACT_GUARD
+
     {% if bed_mesh_enabled %}
         BED_MESH_CLEAR
     {% endif %}

--- a/macros/base/probing/generic_probe.cfg
+++ b/macros/base/probing/generic_probe.cfg
@@ -24,13 +24,14 @@ gcode:
             _ATTACH_PROBE
         {% endif %}
 
-    # If a contact probe needs a temperature guard, route lifecycle through the framework
+    # If a contact probe needs a temperature guard, route lifecycle through the framework.
+    # A guard still active here was left by an interrupted operation: clear it first so
+    # the temperature clamp is applied fresh for this activation instead of being skipped
     {% elif printer["gcode_macro _USER_VARIABLES"].probe_needs_contact_temp_guard|default(False) %}
-        {% if not printer["gcode_macro _PROBE_FRAMEWORK_STATE"].active %}
-            _PROBE_ENTER_CONTACT_GUARD OPERATION=activate_probe SOURCE={source}
-            {% if "_PROBE_HOOK_CONTACT_ACTIVATE" in printer.gcode.commands %}
-                _PROBE_HOOK_CONTACT_ACTIVATE SOURCE={source}
-            {% endif %}
+        _PROBE_RESET_CONTACT_GUARD
+        _PROBE_ENTER_CONTACT_GUARD OPERATION=activate_probe SOURCE={source}
+        {% if "_PROBE_HOOK_CONTACT_ACTIVATE" in printer.gcode.commands %}
+            _PROBE_HOOK_CONTACT_ACTIVATE SOURCE={source}
         {% endif %}
     {% endif %}
 
@@ -53,12 +54,19 @@ gcode:
             _DOCK_PROBE
         {% endif %}
 
-    # If a contact probe needs a temperature guard, route lifecycle through the framework
+    # If a contact probe needs a temperature guard, route lifecycle through the framework.
+    # Only a guard entered by ACTIVATE_PROBE is exited here; a guard owned by another
+    # operation is stale and is cleared without reheating to its saved target
     {% elif printer["gcode_macro _USER_VARIABLES"].probe_needs_contact_temp_guard|default(False) %}
-        {% if printer["gcode_macro _PROBE_FRAMEWORK_STATE"].active %}
-            {% if "_PROBE_HOOK_CONTACT_DEACTIVATE" in printer.gcode.commands %}
-                _PROBE_HOOK_CONTACT_DEACTIVATE SOURCE={source}
+        {% set state = printer["gcode_macro _PROBE_FRAMEWORK_STATE"] %}
+        {% if state.active %}
+            {% if state.operation == "activate_probe" %}
+                {% if "_PROBE_HOOK_CONTACT_DEACTIVATE" in printer.gcode.commands %}
+                    _PROBE_HOOK_CONTACT_DEACTIVATE SOURCE={source}
+                {% endif %}
+                _PROBE_EXIT_CONTACT_GUARD
+            {% else %}
+                _PROBE_RESET_CONTACT_GUARD
             {% endif %}
-            _PROBE_EXIT_CONTACT_GUARD
         {% endif %}
     {% endif %}

--- a/macros/base/probing/virtual_z_probe.cfg
+++ b/macros/base/probing/virtual_z_probe.cfg
@@ -49,7 +49,7 @@ gcode:
     {% endif %}
 
     {% if state.active %}
-        { action_raise_error("Contact probe guard is already active for operation '%s' from SOURCE '%s'" % (state.operation, state.source)) }
+        { action_raise_error("Contact probe guard is already active (operation '%s', source '%s'). START_PRINT or ACTIVATE_PROBE clears a stale guard automatically." % (state.operation, state.source)) }
     {% endif %}
 
     {% if vars.probe_contact_max_temp is defined %}
@@ -70,6 +70,10 @@ gcode:
     SET_GCODE_VARIABLE MACRO=_PROBE_FRAMEWORK_STATE VARIABLE=saved_temperature VALUE={ target_temperature }
     SET_GCODE_VARIABLE MACRO=_PROBE_FRAMEWORK_STATE VARIABLE=operation VALUE='"{operation}"'
     SET_GCODE_VARIABLE MACRO=_PROBE_FRAMEWORK_STATE VARIABLE=source VALUE='"{source}"'
+
+    {% if vars.verbose %}
+        RESPOND MSG="Contact probe guard: entered for operation '{operation}' (source: {source}), extruder target {target_temperature}C saved, probing limit {max_probing_temp}C"
+    {% endif %}
 
     {% if target_temperature > max_probing_temp %}
         M106 S255
@@ -115,6 +119,10 @@ gcode:
         SET_GCODE_VARIABLE MACRO=_PROBE_FRAMEWORK_STATE VARIABLE=saved_temperature VALUE={ 0 }
         SET_GCODE_VARIABLE MACRO=_PROBE_FRAMEWORK_STATE VARIABLE=operation VALUE='""'
         SET_GCODE_VARIABLE MACRO=_PROBE_FRAMEWORK_STATE VARIABLE=source VALUE='""'
+
+        {% if vars.verbose %}
+            RESPOND MSG="Contact probe guard: exited for operation '{state.operation}', extruder target {state.saved_temperature}C restored"
+        {% endif %}
     {% endif %}
 
 
@@ -133,6 +141,29 @@ gcode:
             SET_GCODE_VARIABLE MACRO=_PROBE_FRAMEWORK_STATE VARIABLE=saved_temperature VALUE={ 0 }
             SET_GCODE_VARIABLE MACRO=_PROBE_FRAMEWORK_STATE VARIABLE=operation VALUE='""'
             SET_GCODE_VARIABLE MACRO=_PROBE_FRAMEWORK_STATE VARIABLE=source VALUE='""'
+        {% endif %}
+    {% else %}
+        RESPOND MSG="Contact probe guard: no active guard, nothing to recover"
+    {% endif %}
+
+
+[gcode_macro _PROBE_RESET_CONTACT_GUARD]
+description: Silently clear contact guard state left over from an interrupted operation
+gcode:
+    {% set state = printer["gcode_macro _PROBE_FRAMEWORK_STATE"] %}
+    {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
+    {% set restore_target = params.RESTORE_TARGET|default(0)|int %}
+
+    {% if state.active %}
+        {% if restore_target == 1 %}
+            M104 S{state.saved_temperature}
+        {% endif %}
+        SET_GCODE_VARIABLE MACRO=_PROBE_FRAMEWORK_STATE VARIABLE=active VALUE={ False }
+        SET_GCODE_VARIABLE MACRO=_PROBE_FRAMEWORK_STATE VARIABLE=saved_temperature VALUE={ 0 }
+        SET_GCODE_VARIABLE MACRO=_PROBE_FRAMEWORK_STATE VARIABLE=operation VALUE='""'
+        SET_GCODE_VARIABLE MACRO=_PROBE_FRAMEWORK_STATE VARIABLE=source VALUE='""'
+        {% if verbose %}
+            RESPOND MSG="Contact probe guard: cleared stale guard from operation '{state.operation}' (source: {state.source})"
         {% endif %}
     {% endif %}
 

--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -105,6 +105,11 @@ gcode:
 
     CLEAR_PAUSE
 
+    # Clear any contact probe guard left over from a previously interrupted probing
+    # operation so the print is not blocked. Temperatures are managed by the
+    # START_PRINT sequence itself, so the guard's saved target is not restored
+    _PROBE_RESET_CONTACT_GUARD
+
     {% if bed_mesh_enabled %}
         BED_MESH_CLEAR
     {% endif %}

--- a/scripts/validate_probe_framework.py
+++ b/scripts/validate_probe_framework.py
@@ -21,8 +21,24 @@ REQUIRED_REPO_PATHS = {
     "config/machine.cfg": "file",
     "config/hardware/probes": "dir",
     "macros/base/probing": "dir",
+    "macros/base/probing/generic_probe.cfg": "file",
+    "macros/base/probing/virtual_z_probe.cfg": "file",
+    "macros/base/start_print.cfg": "file",
+    "macros/base/cancel_print.cfg": "file",
+    "macros/base/end_print.cfg": "file",
     "scripts": "dir",
 }
+GUARD_RESET_MACRO = "_PROBE_RESET_CONTACT_GUARD"
+GUARD_ENTER_MACRO = "_PROBE_ENTER_CONTACT_GUARD"
+GUARD_EXIT_MACRO = "_PROBE_EXIT_CONTACT_GUARD"
+# Print lifecycle entry points that must clear a contact guard leaked by an
+# interrupted guarded operation
+GUARD_CLEANUP_CALLERS = (
+    "macros/base/start_print.cfg",
+    "macros/base/cancel_print.cfg",
+    "macros/base/end_print.cfg",
+    "config/machine.cfg",
+)
 
 
 def read(path: Path) -> str:
@@ -67,6 +83,49 @@ def has_macro(text: str, macro: str) -> bool:
     return re.search(rf"^\s*\[gcode_macro\s+{re.escape(macro)}\]\s*(?:#.*)?$", text, re.M) is not None
 
 
+def calls_macro(text: str, macro: str) -> bool:
+    return re.search(rf"^\s*{re.escape(macro)}\b", text, re.M) is not None
+
+
+def macro_bodies(text: str) -> dict[str, str]:
+    bodies: dict[str, str] = {}
+    headers = list(re.finditer(r"^\s*\[gcode_macro\s+([^\]]+)\]\s*(?:#.*)?$", text, re.M))
+    for index, header in enumerate(headers):
+        end = headers[index + 1].start() if index + 1 < len(headers) else len(text)
+        bodies[header.group(1).strip()] = text[header.end():end]
+    return bodies
+
+
+def validate_guard_cleanup(repo: Path) -> list[str]:
+    errors: list[str] = []
+
+    framework_file = repo / "macros" / "base" / "probing" / "virtual_z_probe.cfg"
+    framework_text = read(framework_file)
+    if not has_macro(framework_text, GUARD_RESET_MACRO):
+        errors.append(f"{framework_file}: {GUARD_RESET_MACRO} is not defined")
+
+    for relative_path in GUARD_CLEANUP_CALLERS:
+        path = repo / relative_path
+        if not calls_macro(read(path), GUARD_RESET_MACRO):
+            errors.append(f"{path}: must call {GUARD_RESET_MACRO} to clear a stale contact guard")
+
+    # Guarded wrappers in the framework must pair enter with exit in the same macro.
+    # generic_probe.cfg is the one sanctioned cross-macro pair: ACTIVATE_PROBE enters
+    # and DEACTIVATE_PROBE exits.
+    for name, body in macro_bodies(framework_text).items():
+        if calls_macro(body, GUARD_ENTER_MACRO) and not calls_macro(body, GUARD_EXIT_MACRO):
+            errors.append(f"{framework_file}: [gcode_macro {name}] enters the contact guard but never exits it")
+
+    generic_file = repo / "macros" / "base" / "probing" / "generic_probe.cfg"
+    activate_body = macro_bodies(read(generic_file)).get("ACTIVATE_PROBE", "")
+    enter_call = re.search(rf"^\s*{GUARD_ENTER_MACRO}\b", activate_body, re.M)
+    reset_call = re.search(rf"^\s*{GUARD_RESET_MACRO}\b", activate_body, re.M)
+    if enter_call and (reset_call is None or reset_call.start() > enter_call.start()):
+        errors.append(f"{generic_file}: ACTIVATE_PROBE must clear a stale contact guard before entering a new one")
+
+    return errors
+
+
 def validate_repo_layout(repo: Path) -> list[str]:
     errors: list[str] = []
     if not repo.is_dir():
@@ -86,6 +145,8 @@ def validate(repo: Path) -> list[str]:
     errors = validate_repo_layout(repo)
     if errors:
         return errors
+
+    errors.extend(validate_guard_cleanup(repo))
 
     profiles_dir = repo / "config" / "hardware" / "probes"
     hooks_dir = repo / "macros" / "base" / "probing" / "hooks"

--- a/tests/test_probe_framework_validator.py
+++ b/tests/test_probe_framework_validator.py
@@ -27,17 +27,61 @@ def startprint_actions(text: str) -> tuple[str, ...]:
     return ast.literal_eval(profile_variable(text, "startprint_actions"))
 
 
+MINIMAL_MACHINE_CFG = """[virtual_sdcard]
+on_error_gcode:
+    _PROBE_RESET_CONTACT_GUARD
+"""
+
+MINIMAL_VIRTUAL_Z_PROBE_CFG = """[gcode_macro _PROBE_RESET_CONTACT_GUARD]
+gcode:
+
+[gcode_macro _PROBE_CONTACT_Z_HOME]
+gcode:
+    _PROBE_ENTER_CONTACT_GUARD OPERATION=contact_z_home SOURCE=manual
+    _PROBE_EXIT_CONTACT_GUARD
+"""
+
+MINIMAL_GENERIC_PROBE_CFG = """[gcode_macro ACTIVATE_PROBE]
+gcode:
+    _PROBE_RESET_CONTACT_GUARD
+    _PROBE_ENTER_CONTACT_GUARD OPERATION=activate_probe SOURCE=manual
+
+[gcode_macro DEACTIVATE_PROBE]
+gcode:
+    _PROBE_EXIT_CONTACT_GUARD
+"""
+
+
+def minimal_lifecycle_macro(name: str) -> str:
+    return f"[gcode_macro {name}]\ngcode:\n    _PROBE_RESET_CONTACT_GUARD\n"
+
+
 def make_minimal_repo(tmp_path: Path) -> Path:
     repo = tmp_path
     (repo / "README.md").write_text("", encoding="utf-8")
     (repo / "config").mkdir()
-    (repo / "config" / "machine.cfg").write_text("", encoding="utf-8")
+    (repo / "config" / "machine.cfg").write_text(MINIMAL_MACHINE_CFG, encoding="utf-8")
     (repo / "config" / "hardware").mkdir()
     (repo / "config" / "hardware" / "probes").mkdir()
     (repo / "macros").mkdir()
     (repo / "macros" / "base").mkdir()
     (repo / "macros" / "base" / "probing").mkdir()
     (repo / "macros" / "base" / "probing" / "hooks").mkdir()
+    (repo / "macros" / "base" / "probing" / "virtual_z_probe.cfg").write_text(
+        MINIMAL_VIRTUAL_Z_PROBE_CFG, encoding="utf-8"
+    )
+    (repo / "macros" / "base" / "probing" / "generic_probe.cfg").write_text(
+        MINIMAL_GENERIC_PROBE_CFG, encoding="utf-8"
+    )
+    (repo / "macros" / "base" / "start_print.cfg").write_text(
+        minimal_lifecycle_macro("START_PRINT"), encoding="utf-8"
+    )
+    (repo / "macros" / "base" / "cancel_print.cfg").write_text(
+        minimal_lifecycle_macro("CANCEL_PRINT"), encoding="utf-8"
+    )
+    (repo / "macros" / "base" / "end_print.cfg").write_text(
+        minimal_lifecycle_macro("END_PRINT"), encoding="utf-8"
+    )
     (repo / "scripts").mkdir()
     return repo
 
@@ -119,6 +163,78 @@ gcode:
                     for error in validator.validate(repo)
                 ),
             )
+
+
+class ContactGuardCleanupTest(unittest.TestCase):
+    def test_compliant_minimal_repo_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = make_minimal_repo(Path(tmpdir))
+
+            self.assertEqual([], validator.validate(repo))
+
+    def test_lifecycle_entry_points_must_clear_stale_guard(self) -> None:
+        for relative_path in validator.GUARD_CLEANUP_CALLERS:
+            with self.subTest(relative_path=relative_path), tempfile.TemporaryDirectory() as tmpdir:
+                repo = make_minimal_repo(Path(tmpdir))
+                path = repo / relative_path
+                path.write_text(
+                    path.read_text(encoding="utf-8").replace("_PROBE_RESET_CONTACT_GUARD", "G4 P0"),
+                    encoding="utf-8",
+                )
+
+                self.assertTrue(
+                    any(
+                        "must call _PROBE_RESET_CONTACT_GUARD" in error and relative_path in error
+                        for error in validator.validate(repo)
+                    ),
+                )
+
+    def test_reset_macro_must_be_defined(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = make_minimal_repo(Path(tmpdir))
+            (repo / "macros" / "base" / "probing" / "virtual_z_probe.cfg").write_text(
+                "[gcode_macro _PROBE_CONTACT_Z_HOME]\ngcode:\n", encoding="utf-8"
+            )
+
+            self.assertTrue(
+                any(
+                    "_PROBE_RESET_CONTACT_GUARD is not defined" in error
+                    for error in validator.validate(repo)
+                ),
+            )
+
+    def test_guarded_wrapper_must_exit_guard(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = make_minimal_repo(Path(tmpdir))
+            (repo / "macros" / "base" / "probing" / "virtual_z_probe.cfg").write_text(
+                MINIMAL_VIRTUAL_Z_PROBE_CFG.replace("    _PROBE_EXIT_CONTACT_GUARD\n", ""),
+                encoding="utf-8",
+            )
+
+            self.assertTrue(
+                any(
+                    "[gcode_macro _PROBE_CONTACT_Z_HOME] enters the contact guard but never exits it" in error
+                    for error in validator.validate(repo)
+                ),
+            )
+
+    def test_activate_probe_must_reset_before_entering_guard(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = make_minimal_repo(Path(tmpdir))
+            (repo / "macros" / "base" / "probing" / "generic_probe.cfg").write_text(
+                MINIMAL_GENERIC_PROBE_CFG.replace("    _PROBE_RESET_CONTACT_GUARD\n", ""),
+                encoding="utf-8",
+            )
+
+            self.assertTrue(
+                any(
+                    "ACTIVATE_PROBE must clear a stale contact guard before entering a new one" in error
+                    for error in validator.validate(repo)
+                ),
+            )
+
+    def test_repo_satisfies_guard_cleanup_contracts(self) -> None:
+        self.assertEqual([], validator.validate_guard_cleanup(REPO_ROOT))
 
 
 class CartographerTouchProfileTest(unittest.TestCase):


### PR DESCRIPTION
## Problem

Klipper aborts the gcode queue on error, so a failed guarded operation never
reaches `_PROBE_EXIT_CONTACT_GUARD` and leaves `_PROBE_FRAMEWORK_STATE.active`
set. Macro variables persist, so the next `START_PRINT` raises "Contact probe
guard is already active" and only a firmware restart clears it. Two user reports.

## Fix

- New `_PROBE_RESET_CONTACT_GUARD` — silent, no motion, no temperature change.
  Called from `START_PRINT`, `CANCEL_PRINT`, `END_PRINT`, `on_error_gcode`.
- `ACTIVATE_PROBE` resets and re-enters instead of skipping guard entry. The
  skip bypassed the temperature clamp, so a stale guard could let a contact
  probe touch the bed at print temperature.
- `DEACTIVATE_PROBE` checks `operation` before exiting, so it won't `M109` to an
  unrelated operation's saved target.

Resets discard the saved target — nozzle position is unknown at failure time.
Reheating stays manual via `_PROBE_RECOVER_CONTACT_GUARD CONFIRM=1`.

## Testing

New validator contracts (fail before, pass after), 9 tests green. Verified on a
Beacon Contact printer: simulated a leaked guard, reset cleared it,
`ACTIVATE_PROBE` re-entered with the live extruder target. Nothing moved,
target stayed at 0.
