### PR TITLE
fix: Pass integer ENABLE to the filament sensor helper

### DIFF
--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -233,7 +233,7 @@ gcode:
     {% endif %}
 
     {% if filament_sensor_available %}
-        _KLIPPAIN_SET_FILAMENT_SENSORS ENABLE={filament_sensor_enabled}
+        _KLIPPAIN_SET_FILAMENT_SENSORS ENABLE={filament_sensor_enabled|int}
     {% endif %}
 
     # And.... Goooo!


### PR DESCRIPTION
With `material_profiles_enabled: False`, `START_PRINT` never enters the material branch, so
`filament_sensor_enabled` stays the boolean it was initialised with and rendered into the macro
call as `ENABLE=True`.

Klipper hands gcode parameters over as strings, and Jinja's `int` filter maps any non-numeric
string to 0. `_KLIPPAIN_SET_FILAMENT_SENSORS` therefore computed `ENABLE=0` and disabled every
configured filament sensor for the whole print. Its own guard (`ENABLE must be 0 or 1`) does not
catch this, because 0 is a legal value.

Checked against Klipper's Jinja environment (`Environment('{%', '%}', '{', '}')`):

| variable | before | helper computes | after | helper computes |
| --- | --- | --- | --- | --- |
| `True` | `ENABLE=True` | 0 | `ENABLE=1` | 1 |
| `False` | `ENABLE=False` | 0 | `ENABLE=0` | 0 |
| `1` | `ENABLE=1` | 1 | `ENABLE=1` | 1 |
| `0` | `ENABLE=0` | 0 | `ENABLE=0` | 0 |

## Fix

Coerce at the call site. The per-material path already yielded an integer, so only setups that
turn material profiles off change behaviour.

