### PR TITLE
feat(bed-fans): Add chamber-temperature-driven bed fan control

### DIFF
--- a/config/hardware/fans/bed_fans.cfg
+++ b/config/hardware/fans/bed_fans.cfg
@@ -1,0 +1,58 @@
+# Bed fans used to circulate heat from the bed into the chamber during heatsoak and printing.
+# Speed is driven by chamber-temperature hysteresis (fast_speed while chasing target, ease to a
+# low slow_speed once reached, resume chasing if it drifts back down), gated so the fans only
+# run while the bed heater actually has a target (see PARAM_FORCE below to bypass that gate for
+# console testing).
+[gcode_macro _USER_VARIABLES]
+variable_bed_fans_enabled: True
+gcode: # do not remove this line
+
+
+[fan_generic bed_fans]
+pin: BED_FANS
+max_power: 1.0
+shutdown_speed: 0.0
+
+[display_template bed_fans_ctrl]
+param_target: 0                    # per-print chamber target °C; bind-time only, 0 disables the fan entirely
+param_force: 0                     # 1 = ignore the bed-heating gate and run anyway; for manual/console testing
+param_fast_speed: 1.0              # speed while chamber is below target
+param_slow_speed: 0.15             # low speed once at or above target - keeps the fan running instead of stopping; keep below param_heatup_speed
+param_max_delta: 1.0               # °C the chamber can drift above/below target before switching speed
+param_heatup_threshold: 0.85       # bed heater power level (0-1) above which the fan is slowed down
+param_heatup_speed: 0.30           # fan speed while the bed heater is working hard - keep above param_slow_speed
+# Klipper persists the fan's own last commanded speed between template ticks, so it doubles as
+# the hysteresis state memory below - no separate state variable needed. The fast phase's floor
+# (once heatup-gate clamped) is heatup_speed, so the fast/slow boundary sits at the midpoint
+# between that floor and slow_speed.
+text:
+    {% set uv = printer["gcode_macro _USER_VARIABLES"] %}
+    {% set fast_speed = uv.bed_fans_fast_speed|default(param_fast_speed)|float %}
+    {% set slow_speed = uv.bed_fans_slow_speed|default(param_slow_speed)|float %}
+    {% set max_delta = uv.bed_fans_max_delta|default(param_max_delta)|float %}
+    {% set heatup_threshold = uv.bed_fans_heatup_threshold|default(param_heatup_threshold)|float %}
+    {% set heatup_threshold = [heatup_threshold, printer.configfile.settings.heater_bed.max_power]|min %}
+    {% set heatup_speed = uv.bed_fans_heatup_speed|default(param_heatup_speed)|float %}
+
+    {% set chamber_sensor_name = uv.chamber_temperature_sensor_name %}
+    {% set chamber_sensor_type = uv.chamber_temperature_sensor_type|default("temperature_sensor") %}
+    {% set chamber_sensor = (chamber_sensor_type ~ " " ~ chamber_sensor_name)|trim %}
+    {% set chamber = printer[chamber_sensor].temperature %}
+    {% set bed_target = printer["heater_bed"].target|default(0)|float %}
+    {% set bed_power = printer["heater_bed"].power|default(0)|float %}
+    {% set speed = 0.0 %}
+    {% if param_target > 0 and (bed_target > 0 or param_force|int == 1) %}
+        {% set ease_above = param_target + max_delta %}
+        {% set engage_below = param_target - max_delta %}
+        {% set last_speed = printer["fan_generic bed_fans"].speed|default(0)|float %}
+        {% set was_fast = last_speed > (slow_speed + heatup_speed) / 2 %}
+        {% if was_fast %}
+            {% set speed = slow_speed if chamber >= ease_above else fast_speed %}
+        {% else %}
+            {% set speed = fast_speed if chamber <= engage_below else slow_speed %}
+        {% endif %}
+        {% if bed_power >= heatup_threshold %}
+            {% set speed = [speed, heatup_speed]|min %}
+        {% endif %}
+    {% endif %}
+    { speed }

--- a/macros/base/cancel_print.cfg
+++ b/macros/base/cancel_print.cfg
@@ -15,6 +15,7 @@ gcode:
     {% set filter_default_time = printer["gcode_macro _USER_VARIABLES"].filter_default_time_on_end_print|default(600)|int %}
     {% set hotend_fan_tach_enabled = printer["gcode_macro _USER_VARIABLES"].hotend_fan_tach_enabled|default(False) %}
     {% set retract_length = printer["gcode_macro _USER_VARIABLES"].retract_length|default(20)|float %}
+    {% set bed_fans_enabled = printer["gcode_macro _USER_VARIABLES"].bed_fans_enabled|default(False) %}
     
     {% if printer.toolhead.homed_axes == "xyz" %}
         PARK
@@ -64,6 +65,12 @@ gcode:
             START_FILTER SPEED=1
             UPDATE_DELAYED_GCODE ID=_STOP_FILTER_DELAYED DURATION={FILTER_TIME}
         {% endif %}
+    {% endif %}
+
+    # Unbind the bed fans template and stop the fans since the print is being cancelled
+    {% if bed_fans_enabled %}
+        SET_FAN_SPEED FAN=bed_fans TEMPLATE=""
+        SET_FAN_SPEED FAN=bed_fans SPEED=0
     {% endif %}
 
     {% if light_enabled %}

--- a/macros/base/end_print.cfg
+++ b/macros/base/end_print.cfg
@@ -17,6 +17,7 @@ gcode:
     {% set filter_default_time = printer["gcode_macro _USER_VARIABLES"].filter_default_time_on_end_print|default(600)|int %}
     {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled|default(False) %}
     {% set hotend_fan_tach_enabled = printer["gcode_macro _USER_VARIABLES"].hotend_fan_tach_enabled|default(False) %}
+    {% set bed_fans_enabled = printer["gcode_macro _USER_VARIABLES"].bed_fans_enabled|default(False) %}
 
     PARK
 
@@ -67,6 +68,12 @@ gcode:
             START_FILTER SPEED=1
             UPDATE_DELAYED_GCODE ID=_STOP_FILTER_DELAYED DURATION={FILTER_TIME}
         {% endif %}
+    {% endif %}
+
+    # Unbind the bed fans template and stop the fans now that the print is done
+    {% if bed_fans_enabled %}
+        SET_FAN_SPEED FAN=bed_fans TEMPLATE=""
+        SET_FAN_SPEED FAN=bed_fans SPEED=0
     {% endif %}
 
     {% if light_enabled %}

--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -289,6 +289,7 @@ gcode:
 
     {% set status_leds_control_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_control_enabled|default(False) %}
     {% set filter_enabled = printer["gcode_macro _USER_VARIABLES"].filter_enabled %}
+    {% set bed_fans_enabled = printer["gcode_macro _USER_VARIABLES"].bed_fans_enabled|default(False) %}
 
     {% set St = printer["gcode_macro _USER_VARIABLES"].travel_speed * 60 %}
 
@@ -297,6 +298,13 @@ gcode:
 
     {% if status_leds_control_enabled %}
         STATUS_LEDS COLOR="HEATING"
+    {% endif %}
+
+    # If bed fans are connected, bind their chamber-temperature-driven speed control as early
+    # as possible, right alongside the bed heating below, so they help spread heat into the
+    # chamber during the heatsoak
+    {% if bed_fans_enabled %}
+        SET_FAN_SPEED FAN=bed_fans TEMPLATE=bed_fans_ctrl PARAM_TARGET={CHAMBER_TEMP}
     {% endif %}
 
     {% if printer.heater_bed.temperature < (BED_TEMP - 8) %}

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -258,6 +258,17 @@ variable_mmu_check_errors_on_start_print: False  # Set to True if you want an ea
 variable_filter_default_time_on_end_print: 600 # seconds
 
 ################################################
+## Bed fans specific variables
+################################################
+## This section is only considered if bed fans are available (and enabled)
+
+variable_bed_fans_fast_speed: 1.0              # speed while chamber is below target
+variable_bed_fans_slow_speed: 0.15             # low speed once at or above target - keeps the fan running instead of stopping
+variable_bed_fans_max_delta: 1.0               # °C the chamber can drift above/below target before switching speed
+variable_bed_fans_heatup_threshold: 0.85       # bed heater power level (0-1) above which the fan is slowed down
+variable_bed_fans_heatup_speed: 0.30           # fan speed while the bed heater is working hard - keep above slow_speed
+
+################################################
 # Other hardware options used in the macros
 ################################################
 


### PR DESCRIPTION
## Summary
- Adds an optional `bed_fans` hardware component (`fan_generic` + `display_template`) that drives dedicated bed fans off a chamber-temperature taper, replacing the "fake chamber heater" hack (`heater_generic`/`verify_heater` spoofing a fan as a heater) that's been circulating in the Klipper community.
- Speed clamps down while the bed heater's PWM duty cycle is high (so the fans don't fight the bed heater during heatup) and is gated to only run while the bed heater has an actual target, with a `PARAM_FORCE` override for manual/console testing.
- Auto-engages from `_MODULE_HEATSOAK_BED` and shuts down from `END_PRINT`/`CANCEL_PRINT`, following the same enabled-flag pattern as the existing recirculating filter support. Tunables are sourced from `_USER_VARIABLES` with defaults shipped in `user_templates/variables.cfg`.

## Test plan
- [x] Validated live via Moonraker console commands on a real printer (dual-fan hardware via `multi_pin`): gate on/off, `PARAM_FORCE` bypass, chamber-temperature taper, and the bed-heatup-power clamp all produced the expected fan speeds.
- [x] Confirmed `FIRMWARE_RESTART` loads cleanly with the new hardware file included.
- [ ] No automated tests added (pure Klipper config/macro change, no Python).