### PR TITLE
fix: Correct Jinja truthiness bugs in COMPUTE_MESH_PARAMETERS

### DIFF
--- a/macros/calibration/adaptive_bed_mesh.cfg
+++ b/macros/calibration/adaptive_bed_mesh.cfg
@@ -64,7 +64,7 @@ gcode:
     {% set xMeshPPS, yMeshPPS = (printer["configfile"].config["bed_mesh"]["mesh_pps"]|default('2,2')).split(',')|map('trim')|map('int') %}
 
     {% set margin = params.MARGIN|default(5)|int %} # additional margin to mesh around the first layer
-    {% set force_mesh = params.FORCE_MESH|default(False) %} # force the mesh even if it's a small part (ie. computed less than 3x3)
+    {% set force_mesh = params.FORCE_MESH|default(0)|int != 0 %} # force the mesh even if it's a small part (ie. computed less than 3x3)
 
 
     # 2 ----- GET FIRST LAYER COORDINATES and SIZE -------------------------------------
@@ -98,7 +98,7 @@ gcode:
 
     # If the first layer size was correctly retrieved, we can do the adaptive bed mesh logic, else we
     # fallback to the original and nominal BED_MESH_CALIBRATE function (full bed probing)
-    {% if xMinSpec and yMinSpec and xMaxSpec and yMaxSpec %}
+    {% if coordinatesFound %}
 
         # 3 ----- APPLY MARGINS ----------------------------------------------
         # We use min/max function as we want it to be constrained by the original


### PR DESCRIPTION
Klipper passes macro parameters to Jinja as strings, so FORCE_MESH=0 became the non-empty string "0", which is truthy. This made FORCE_MESH=0 behave the same as FORCE_MESH=1, with no way to explicitly disable forced meshing on small parts (#799).

Separately, the adaptive-vs-nominal branch checked the truthiness of xMinSpec/yMinSpec/xMaxSpec/yMaxSpec directly, even though 0 is a valid coordinate and evaluates as falsy in Jinja. A first-layer bounding box touching X=0 or Y=0 (e.g. SIZE=0_20_100_100) would fail that check and silently fall back to a full nominal mesh instead of the intended adaptive one, despite coordinatesFound already correctly tracking that valid coordinates were found (#798).

FORCE_MESH is now cast to int and compared explicitly, matching the boolean-parameter convention used elsewhere in the macros. The adaptive-mesh branch now checks coordinatesFound directly instead of re-deriving it from truthiness of the coordinate values.