### PR TITLE
fix: Reheat and physically unretract before resume returns to print

### DIFF
--- a/macros/base/park.cfg
+++ b/macros/base/park.cfg
@@ -1,5 +1,7 @@
 [gcode_macro PARK]
 description: Park the toolhead at the back and retract some filament if the nozzle is hot
+variable_last_retract_mode: "none"
+variable_last_retract_e: 0.0
 gcode:
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
     {% set material = printer['gcode_macro START_PRINT'].material %}
@@ -35,6 +37,8 @@ gcode:
     
     SAVE_GCODE_STATE NAME=PARK
 
+    SET_GCODE_VARIABLE MACRO=PARK VARIABLE=last_retract_mode VALUE='"none"'
+
     {% if printer.extruder.can_extrude %}
         {% if params.E is defined %}
             {% set E = params.E|float|abs %}
@@ -48,6 +52,7 @@ gcode:
                     RESPOND MSG="Firmware retraction enabled, Extruder retraction = {printer.firmware_retraction.retract_length}"
                 {% endif %}
                 G10
+                SET_GCODE_VARIABLE MACRO=PARK VARIABLE=last_retract_mode VALUE='"fw"'
             {% else %}                              # otherwise:
                 {% if printer["gcode_macro _USER_VARIABLES"].material_parameters[material] is defined %}          # use material parameter if available for retract, otherwise use default value
                     {% set E = printer["gcode_macro _USER_VARIABLES"].material_parameters[material].retract_length|default(1.7) %}
@@ -64,6 +69,8 @@ gcode:
         {% if E is defined and E > 0 %}
             G92 E0
             G1 E-{E} F2100
+            SET_GCODE_VARIABLE MACRO=PARK VARIABLE=last_retract_mode VALUE='"manual"'
+            SET_GCODE_VARIABLE MACRO=PARK VARIABLE=last_retract_e VALUE={E}
         {% endif %}
     {% endif %}
 

--- a/macros/base/pause_resume.cfg
+++ b/macros/base/pause_resume.cfg
@@ -40,10 +40,24 @@ gcode:
     {% set klippain_mmu_enabled = printer["gcode_macro _USER_VARIABLES"].klippain_mmu_enabled %}
     {% set idle_timeout_on_pause = printer["gcode_macro _USER_VARIABLES"].idle_timeout_on_pause|default(0)|int %}
     {% set turn_off_extruder = printer["gcode_macro _USER_VARIABLES"].turn_off_extruder_on_pause %}
+    {% set park_retract_mode = printer["gcode_macro PARK"].last_retract_mode %}
+    {% set park_retract_e = printer["gcode_macro PARK"].last_retract_e %}
 
     {% if not printer.pause_resume.is_paused %}
         RESPOND MSG="Print is not paused. Resume ignored"
     {% else %}
+        {% if turn_off_extruder and extruder_target_temp > 0 %}
+            M109 S{extruder_target_temp|int}
+        {% endif %}
+
+        {% if park_retract_mode == "fw" %}
+            G11
+        {% elif park_retract_mode == "manual" %}
+            G92 E0
+            G1 E{park_retract_e} F2100
+        {% endif %}
+        SET_GCODE_VARIABLE MACRO=PARK VARIABLE=last_retract_mode VALUE='"none"'
+
         {% if klippain_mmu_enabled %}
             {% if printer.mmu.enabled and printer.mmu.is_locked %}
                 RESTORE_GCODE_STATE NAME=PAUSE_state MOVE=0
@@ -60,10 +74,6 @@ gcode:
 
         {% if idle_timeout_on_pause > 0%}
             SET_IDLE_TIMEOUT TIMEOUT={printer.configfile.settings.idle_timeout.timeout}
-        {% endif %}
-
-        {% if turn_off_extruder and extruder_target_temp > 0 %}
-            M109 S{extruder_target_temp|int}
         {% endif %}
 
         BASE_RESUME


### PR DESCRIPTION
PARK physically retracts the extruder (G10 or a manual G1 E- move) when pausing, but RESUME never reversed it. Klipper's RESTORE_GCODE_STATE only rebases the logical E bookkeeping on restore; it never re-issues a physical extruder move, so the nozzle stayed retracted after every resume, causing under-extrusion at the resume point (#796).

RESUME also restored the toolhead to the print position before reheating when turn_off_extruder_on_pause was set, leaving a cold or partially cooled nozzle sitting on the model while M109 waited for temperature, risking dragging or oozing onto the print (#797).

PARK now records which retract method and distance it actually used. RESUME reheats first, then reverses that exact retract (G11 for firmware retraction, or the matching G1 E move) while still parked, and only then moves the toolhead back and calls BASE_RESUME.