### PR TITLE
fix(probe): Avoid diagonal moves when docking/attaching the probe

### DIFF
--- a/macros/base/probing/dockable_probe.cfg
+++ b/macros/base/probing/dockable_probe.cfg
@@ -71,10 +71,21 @@ gcode:
         'dock'  : { 'x':  0, 'y':  0 }
     } %}
 
-    {% if location in location_factor %}
-        G1 X{probe_dock_location_x + location_factor[location].x * distance} Y{probe_dock_location_y + location_factor[location].y * distance} F{speed}
-    {% else %}
+    {% if location not in location_factor %}
         { action_raise_error("Error in probe attach/dock movement. Check the directions in your variables.cfg file!") }
+    {% endif %}
+
+    {% set target_x = probe_dock_location_x + location_factor[location].x * distance %}
+    {% set target_y = probe_dock_location_y + location_factor[location].y * distance %}
+
+    # Move the offset axis first, to reach a safe standoff distance before sliding into the
+    # dock's row/column - avoids a diagonal path that can clip the frame on tighter builds
+    {% if location_factor[location].x != 0 %}
+        G1 X{target_x} F{speed}
+        G1 Y{target_y} F{speed}
+    {% else %}
+        G1 Y{target_y} F{speed}
+        G1 X{target_x} F{speed}
     {% endif %}
 
 


### PR DESCRIPTION
_PROBE_MOVE_TO moved to every dock-relative staging position with a single diagonal G1 X.. Y.. command, interpolating both axes simultaneously. On tighter frames this diagonal path can clip the machine - reported in #343 on a Rook 2020 build, where the X carriage hits the Z idler - even though a purely axis-sequential path stays clear.

Move the axis carrying the LOCATION's offset first, then the axis that lands on the dock's own coordinate, derived directly from the same location_factor dict already used to compute the target rather than a second, hand-maintained classification of which named directions are "horizontal" vs "vertical". Every existing call site chains through a staging position before/after LOCATION=dock, so by construction one of the two moves in a given call is always a no-op relative to whatever the previous call already aligned - this holds regardless of which named directions are mixed.