### PR TITLE
fix(mmu): Sync gear/extruder during purge and prime line

### DIFF
--- a/macros/helpers/filament_swap.cfg
+++ b/macros/helpers/filament_swap.cfg
@@ -29,6 +29,7 @@ gcode:
     {% endif %}
 
     {% if klippain_mmu_enabled %}
+        {% set was_clog_detection = printer.mmu.clog_detection %}
         _KLIPPAIN_MMU_SET_CLOGDETECTION STATE=0
     {% endif %}
 
@@ -54,7 +55,10 @@ gcode:
     {% endif %}
 
     {% if klippain_mmu_enabled %}
-        _KLIPPAIN_MMU_SET_CLOGDETECTION STATE={printer.mmu.clog_detection}
+        # _KLIPPAIN_MMU_SET_CLOGDETECTION STATE=0 above already zeroed the live
+        # printer.mmu.clog_detection status, so restoring from that value here would just
+        # disable it again - restore the value captured before we touched it instead
+        _KLIPPAIN_MMU_SET_CLOGDETECTION STATE={was_clog_detection}
     {% endif %}
 
 
@@ -76,6 +80,7 @@ gcode:
     {% endif %}
 
     {% if klippain_mmu_enabled %}
+        {% set was_clog_detection = printer.mmu.clog_detection %}
         _KLIPPAIN_MMU_SET_CLOGDETECTION STATE=0
     {% endif %}
 
@@ -100,7 +105,10 @@ gcode:
     {% endif %}
 
     {% if klippain_mmu_enabled %}
-        _KLIPPAIN_MMU_SET_CLOGDETECTION STATE={printer.mmu.clog_detection}
+        # _KLIPPAIN_MMU_SET_CLOGDETECTION STATE=0 above already zeroed the live
+        # printer.mmu.clog_detection status, so restoring from that value here would just
+        # disable it again - restore the value captured before we touched it instead
+        _KLIPPAIN_MMU_SET_CLOGDETECTION STATE={was_clog_detection}
     {% endif %}
 
 
@@ -121,6 +129,7 @@ gcode:
     {% endif %}
 
      {% if klippain_mmu_enabled %}
+        {% set was_clog_detection = printer.mmu.clog_detection %}
         _KLIPPAIN_MMU_SET_CLOGDETECTION STATE=0
     {% endif %}
 
@@ -156,5 +165,8 @@ gcode:
     {% endif %}
 
     {% if klippain_mmu_enabled %}
-        _KLIPPAIN_MMU_SET_CLOGDETECTION STATE={printer.mmu.clog_detection}
+        # _KLIPPAIN_MMU_SET_CLOGDETECTION STATE=0 above already zeroed the live
+        # printer.mmu.clog_detection status, so restoring from that value here would just
+        # disable it again - restore the value captured before we touched it instead
+        _KLIPPAIN_MMU_SET_CLOGDETECTION STATE={was_clog_detection}
     {% endif %}

--- a/macros/helpers/nozzle_cleaning.cfg
+++ b/macros/helpers/nozzle_cleaning.cfg
@@ -87,6 +87,7 @@ gcode:
     {% set purgeclean_servo_enabled = printer["gcode_macro _USER_VARIABLES"].purgeclean_servo_enabled %}
     {% set status_leds_control_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_control_enabled|default(False) %}
     {% set filament_sensor_enabled = printer["gcode_macro _USER_VARIABLES"].filament_sensor_enabled|default(False) %}
+    {% set klippain_mmu_enabled = printer["gcode_macro _USER_VARIABLES"].klippain_mmu_enabled %}
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
 
     {% if purge_and_brush_enabled %}
@@ -109,6 +110,16 @@ gcode:
 
         _CONDITIONAL_MOVE_TO_PURGE_BUCKET Z_DROP={Z_DROP}
 
+        {% if klippain_mmu_enabled and printer.mmu.tool|int != -2 %}
+            {% set was_synced = printer.mmu.sync_drive %}
+            {% set was_clog_detection = printer.mmu.clog_detection %}
+            _KLIPPAIN_MMU_SET_CLOGDETECTION STATE=0
+            # HH only restores gear/extruder sync right before the print resumes, so a custom
+            # macro extruding this soon after a tool load (see moggieuk/Happy-Hare#178) needs to
+            # request it explicitly, or the extruder pushes this volume alone
+            MMU_SYNC_GEAR_MOTOR SYNC=1
+        {% endif %}
+
         # Heat if needed and purge
         _LOW_TEMP_CHECK T={TEMP}
         G92 E0
@@ -119,6 +130,20 @@ gcode:
         G1 E-{RETRACT * 0.1} F2100
         G1 E-{RETRACT - (RETRACT * 0.1)} F150
         G92 E0
+
+        {% if klippain_mmu_enabled and printer.mmu.tool|int != -2 %}
+            # Flush Klipper's queue first - MMU_SYNC_GEAR_MOTOR isn't motion-queued the same way
+            # as the G1 E moves above, so without this it can restore sync/clog-detection before
+            # those queued moves have physically finished
+            M400
+            # Manual sync overrides are sticky until the next tool change, so restore the actual
+            # live state captured before we forced it on, not a static config-file value
+            MMU_SYNC_GEAR_MOTOR SYNC={1 if was_synced else 0}
+            # _KLIPPAIN_MMU_SET_CLOGDETECTION STATE=0 above already zeroed the live
+            # printer.mmu.clog_detection status, so restoring from that value here would just
+            # disable it again - restore the value captured before we touched it instead
+            _KLIPPAIN_MMU_SET_CLOGDETECTION STATE={was_clog_detection}
+        {% endif %}
 
         # Wait some time to let the nozzle ooze before cleaning
         # No M400 needed here since G4 is also flushing Klipper's buffer

--- a/macros/helpers/prime_line.cfg
+++ b/macros/helpers/prime_line.cfg
@@ -88,8 +88,14 @@ gcode:
     # Finally we compute the speed to get the correct flowrate for the prime line
     {% set speed = (prime_line_flowrate / (prime_line_height * line_width)) * 60 |float %}
 
-    {% if klippain_mmu_enabled %}
+    {% if klippain_mmu_enabled and printer.mmu.tool|int != -2 %}
+        {% set was_synced = printer.mmu.sync_drive %}
+        {% set was_clog_detection = printer.mmu.clog_detection %}
         _KLIPPAIN_MMU_SET_CLOGDETECTION STATE=0
+        # HH only restores gear/extruder sync right before the print resumes, so a custom
+        # macro extruding this soon after a tool load (see moggieuk/Happy-Hare#178) needs to
+        # request it explicitly, or the extruder pushes this volume alone
+        MMU_SYNC_GEAR_MOTOR SYNC=1
     {% endif %}
 
     {% if filament_sensor_enabled %}
@@ -149,8 +155,14 @@ gcode:
     # Flushing Klipper's buffer to ensure the primeline sequence is done before continuing
     M400
 
-    {% if klippain_mmu_enabled %}
-        _KLIPPAIN_MMU_SET_CLOGDETECTION STATE={printer.mmu.clog_detection}
+    {% if klippain_mmu_enabled and printer.mmu.tool|int != -2 %}
+        # Manual sync overrides are sticky until the next tool change, so restore the actual
+        # live state captured before we forced it on, not a static config-file value
+        MMU_SYNC_GEAR_MOTOR SYNC={1 if was_synced else 0}
+        # _KLIPPAIN_MMU_SET_CLOGDETECTION STATE=0 above already zeroed the live
+        # printer.mmu.clog_detection status, so restoring from that value here would just
+        # disable it again - restore the value captured before we touched it instead
+        _KLIPPAIN_MMU_SET_CLOGDETECTION STATE={was_clog_detection}
     {% endif %}
 
     {% if filament_sensor_enabled %}


### PR DESCRIPTION
  `PURGE` and `PRIMELINE` extrude a meaningful volume of filament right after a
  tool load (`_KLIPPAIN_MMU_LOAD_INITIAL_TOOL`, called from
  `_MODULE_EXTRUDER_HEATING` before either action runs), but Happy Hare only
  restores gear/extruder sync right before the print resumes — not immediately
  after the load. Per the Happy Hare maintainer's own guidance on this exact
  scenario ([moggieuk/Happy-Hare#178](https://github.com/moggieuk/Happy-Hare/issues/178)),
  a custom macro extruding in that window needs to request sync explicitly with
  `MMU_SYNC_GEAR_MOTOR`, or the extruder pushes that volume alone.

  - `PURGE` and `PRIMELINE` now bracket their extrusion with
    `MMU_SYNC_GEAR_MOTOR SYNC=1`, guarded against bypass mode
    (`printer.mmu.tool != -2`, no gear to sync there), and restore afterward.
  - The restore reads `printer.mmu.sync_drive` (Happy Hare's live sync state),
    captured *before* the override — not
    `printer.configfile.config.mmu.sync_to_extruder` (the static, file-parse-time
    value, which never reflects `_KLIPPAIN_MMU_INIT`'s runtime
    `MMU_TEST_CONFIG` override). Manual sync overrides are sticky until the next
    tool change, so restoring the wrong value would leave sync forced on or off
    for the rest of a single-tool print.
  - Fixes a related pre-existing bug in `PRIMELINE`'s clog-detection bracket:
    `_KLIPPAIN_MMU_SET_CLOGDETECTION STATE={printer.mmu.clog_detection}` was
    reading the live status *after* the disable call had already zeroed it, so
    it always restored `0` and clog detection never actually re-enabled after a
    prime line. `PURGE` gets the same clog-detection bracket added from
    scratch, since it previously had none despite doing the same kind of bulk
    single-shot extrusion.
  - `PURGE`'s restore now flushes with `M400` before touching sync/clog state,
    matching `PRIMELINE`'s existing pattern — `MMU_SYNC_GEAR_MOTOR` isn't
    motion-queued the same way as the `G1 E` moves ahead of it, so without the
    flush it could race ahead and undo the override before the purge extrusion
    physically finished.
  - A second commit fixes the identical clog-detection restore bug in three
    more places found while reviewing the first fix: `UNLOAD_FILAMENT`,
    `LOAD_FILAMENT`, and `_TIP_SHAPING` in `filament_swap.cfg`.