### PR TITLE
fix(homing): Check Z safety before homing X or Y individually

### DIFF
--- a/macros/base/homing/homing_override.cfg
+++ b/macros/base/homing/homing_override.cfg
@@ -78,11 +78,13 @@ gcode:
 
     G90
 
-    {% if Z %}
+    {% if X or Y or Z %}
         {% if ('z' in printer.toolhead.homed_axes) %}
+            # Lift Z first if it's low, regardless of which axes are being homed - avoids
+            # dragging the nozzle during an X/Y-only home
             {% if (printer.toolhead.position.z < homing_zhop) %}
                 {% if verbose %}
-                    { action_respond_info("Z too low, performing ZHOP to rehome Z") }
+                    { action_respond_info("Z too low, performing ZHOP for safety") }
                 {% endif %}
                 G91
                 G0 Z{homing_zhop} F{z_drop_speed}
@@ -90,24 +92,45 @@ gcode:
                 G90
             {% else %}
                 {% if verbose %}
-                    { action_respond_info("Z already safe, no ZHOP needed to rehome Z") }
+                    { action_respond_info("Z already safe, no ZHOP needed") }
                 {% endif %}
             {% endif %}
-        {% elif ('xy' in printer.toolhead.homed_axes) %}
-            {% if verbose %}
-                { action_respond_info("X and Y already homed, no ZHOP needed to home Z") }
+        {% elif Z %}
+            {% if ('xy' in printer.toolhead.homed_axes) %}
+                {% if verbose %}
+                    { action_respond_info("X and Y already homed, no ZHOP needed to home Z") }
+                {% endif %}
+            {% else %}
+                {% if verbose %}
+                    { action_respond_info("X and Y not homed, forcing full G28 to home Z properly") }
+                {% endif %}
+                SET_KINEMATIC_POSITION X=0 Y=0 Z=0
+                G0 Z{homing_zhop} F{z_drop_speed}
+                {% if sensorless_homing_enabled and kinematics == "corexz" %}
+                    # Wait for stallguard registers to clear
+                    M400
+                {% endif %}
+                {% set X, Y, Z = True, True, True %}
             {% endif %}
         {% else %}
+            # Z unknown and not being homed this call (e.g. bare "G28 X") - the bug fixed by #298.
+            # Klipper refuses G0/G1 on unhomed axes, so Z must be marked homed to allow the lift,
+            # then cleared back after. CLEAR_HOMED (mainline) / CLEAR (Kalico) cover both parameter
+            # spellings across Klipper versions/forks; whichever doesn't apply is just ignored.
+            {% set prior_homed = printer.toolhead.homed_axes %}
+            {% set clear_axes = "" %}
+            {% if 'x' not in prior_homed %}{% set clear_axes = clear_axes ~ "X" %}{% endif %}
+            {% if 'y' not in prior_homed %}{% set clear_axes = clear_axes ~ "Y" %}{% endif %}
+            {% if 'z' not in prior_homed %}{% set clear_axes = clear_axes ~ "Z" %}{% endif %}
             {% if verbose %}
-                { action_respond_info("X and Y not homed, forcing full G28 to home Z properly") }
+                { action_respond_info("Z unknown, performing a non-homing ZHOP for safety") }
             {% endif %}
-            SET_KINEMATIC_POSITION X=0 Y=0 Z=0
+            SET_KINEMATIC_POSITION Z=0
+            G91
             G0 Z{homing_zhop} F{z_drop_speed}
-            {% if sensorless_homing_enabled and kinematics == "corexz" %}
-                # Wait for stallguard registers to clear
-                M400
-            {% endif %}
-            {% set X, Y, Z = True, True, True %}
+            M400
+            G90
+            SET_KINEMATIC_POSITION CLEAR_HOMED={clear_axes} CLEAR={clear_axes}
         {% endif %}
     {% endif %}
 


### PR DESCRIPTION
## Summary

Closes #298.

The zhop safety check in `homing_override.cfg` only ran inside `{% if Z %}`,
so it was entirely skipped when homing X or Y alone (e.g. a bare `G28 X`). If
Z was currently low, that left no safety check at all before the X/Y move,
letting the nozzle drag across the bed or a print.

The linked fix in #299 generalized the check to run for any axis correctly,
but introduced a worse version of the exact problem it was trying to solve:
on current mainline Klipper, `SET_KINEMATIC_POSITION`'s `SET_HOMED` defaults
to `"xyz"` regardless of which X/Y/Z position values are given in the same
call, so #299's `SET_KINEMATIC_POSITION Z=0` silently marks X and Y as homed
too — even when neither had ever actually been homed.

This generalizes the same zhop check to run whenever any home is requested,
using the same overall structure #299 used, but the new branch (Z unknown
and not being homed this call — the actual bug scenario) is careful about
homed-status side effects in both directions:

- Klipper refuses `G0`/`G1` on any coordinate it doesn't consider homed
  (`"Must home axis first"`), so Z has to be marked homed to allow the
  protective lift move at all — verified live: an earlier version of this
  fix that tried to clear homed status *before* the move failed outright
  with that error.
- `SET_KINEMATIC_POSITION`'s homed-status handling differs across Klipper
  versions/forks. I verified this directly against two real
  implementations: current mainline Klipper
  (`klippy/extras/force_move.py`) defaults `SET_HOMED` to `"xyz"` unless
  overridden; **Kalico's** version of the same file (verified against a
  real printer's installed copy) has no `SET_HOMED` parameter at all and
  always marks everything homed unconditionally, only supporting clearing
  specific axes afterward via `CLEAR=<list>`. After the lift, this clears
  homed status again using both the `CLEAR_HOMED` (mainline) and `CLEAR`
  (Kalico) parameter spellings together — unrecognized gcode parameters are
  silently ignored either way — for exactly the axes that weren't already
  legitimately homed before this call (captured up front), so anything
  genuinely already homed is never touched.

The pre-existing "X and Y not homed, forcing full G28" branch (now nested
under `{% elif Z %}`) is untouched — it already forces a real, non-partial
`G28` immediately after, so its own `SET_KINEMATIC_POSITION X=0 Y=0 Z=0`
call marking everything homed is harmless there.

## Verified live on real hardware (Kalico)

Through every branch of the restructured logic:
- [x] `G28 X` / `G28 Y` alone from a fully unhomed state: completes without
      error, `homed_axes` afterward contains only what was requested (not
      falsely including Z or the other axis), and `toolhead.position.z`
      confirms the protective lift actually happened.
- [x] `G28 X` with Z genuinely homed but currently below `homing_zhop`: real
      lift occurs (Z: 2.0 → 7.0mm in testing), `homed_axes` stays correctly
      `xyz` throughout since Z really was homed.
- [x] `G28 X` with Z genuinely homed and already above `homing_zhop`: no
      lift occurs (Z position unchanged) — the no-op path still works.
- [x] `G28 Z` with X/Y already homed: homes Z directly with no zhop, as
      before.
- [x] `G28 Z` with nothing homed: forces the existing full-`G28` path, as
      before.
- [x] Full `G28` (no axis params): homes and marks everything, as before.

Not yet tested: mainline Klipper (only had Kalico hardware available) and a
dockable/dockable_virtual probe specifically (tested on TAP, which also
includes this same file). Both should behave correctly per the source-level
analysis above, but haven't been physically confirmed.

**Deliberately not included:** #299 also added a second
`SET_KINEMATIC_POSITION Z=0` immediately before the real `G28 Z0` later in
this file, with a comment that it's needed to allow Z to move after X/Y were
homed individually. Testing above didn't surface a need for it — homing Z
after X/Y were homed individually worked correctly without it — so it's left
out rather than adding unverified code.