### PR TITLE
fix: Throttle recirculating filter while bed is still ramping up

### DIFF
--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -281,14 +281,16 @@ gcode:
     # ----- BED HEATSOAK -------------------------------------
     # Heatsoak the bed if SOAK time is set and bed is not already warming up to the correct temperature (+-8°C).
     # We make the assumption that the soak is not needed if the bed is already at the correct target.
-    # We also use the recirculating filter under the bed (if available) at full power to spread the heat
-    # during the heatsoak if a specific temperature need to be reached.
+    # We also use the recirculating filter under the bed (if available) to spread the heat during
+    # the heatsoak if a specific temperature need to be reached, at a user-tunable speed while
+    # ramping up to target (see variable_filter_heatsoak_speed).
     {% set BED_TEMP = printer["gcode_macro START_PRINT"].bed_temp %}
     {% set SOAK = printer["gcode_macro START_PRINT"].soak %}
     {% set CHAMBER_TEMP = printer["gcode_macro START_PRINT"].chamber_temp %}
 
     {% set status_leds_control_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_control_enabled|default(False) %}
     {% set filter_enabled = printer["gcode_macro _USER_VARIABLES"].filter_enabled %}
+    {% set filter_heatsoak_speed = printer["gcode_macro _USER_VARIABLES"].filter_heatsoak_speed|default(1.0)|float %}
     {% set bed_fans_enabled = printer["gcode_macro _USER_VARIABLES"].bed_fans_enabled|default(False) %}
 
     {% set St = printer["gcode_macro _USER_VARIABLES"].travel_speed * 60 %}
@@ -311,7 +313,7 @@ gcode:
         # If the machine is equiped by a chamber temperature sensor and a recirculating filter (check is automatic under the hood),
         # then we look if a specific chamber temperature is needed and we power on the recirculating filter to spread the heat
         {% if (CHAMBER_TEMP > 0) and filter_enabled %}
-            START_FILTER SPEED=1
+            START_FILTER SPEED={filter_heatsoak_speed}
         {% endif %}
 
         # If we need a full soak (not 0 min), then move the toolhead to the center front to spread the heat using the hotend fan

--- a/macros/helpers/heatsoak.cfg
+++ b/macros/helpers/heatsoak.cfg
@@ -53,6 +53,7 @@ gcode:
 
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
     {% set heaterbed_enabled = printer["gcode_macro _USER_VARIABLES"].heaterbed_enabled %}
+    {% set filter_enabled = printer["gcode_macro _USER_VARIABLES"].filter_enabled %}
     {% set heatsoak_bed_enabled = printer["gcode_macro _USER_VARIABLES"].print_default_soak > 0 %} # configured heatsoak default value
 
     {% if heaterbed_enabled %}
@@ -61,6 +62,11 @@ gcode:
         {% endif %}
 
         M190 S{SETPOINT_TEMP}
+
+        # Bed reached target - bring the filter back to full speed for the soak
+        {% if filter_enabled and printer['fan_generic filter'].speed > 0 %}
+            START_FILTER SPEED=1
+        {% endif %}
 
         {% if TIME > 0 %}
             {% for i in range(0, TIME) %}

--- a/user_templates/variables.cfg
+++ b/user_templates/variables.cfg
@@ -256,6 +256,7 @@ variable_mmu_check_errors_on_start_print: False  # Set to True if you want an ea
 ## This section is only considered if a filter is available (and enabled)
 
 variable_filter_default_time_on_end_print: 600 # seconds
+variable_filter_heatsoak_speed: 1.0 # filter speed (0-1) while the bed is still ramping up to its heatsoak target
 
 ################################################
 ## Bed fans specific variables


### PR DESCRIPTION
START_FILTER was called at SPEED=1 for the entire bed heatsoak, including while the bed heater is still climbing to its target and drawing near-max power. On some machines the filter pulls heat away faster than the heater can replace it, tripping thermal protection or extending heatsoak well past its configured time (#714).

The filter speed while the bed is still ramping up to target is now user-tunable via variable_filter_heatsoak_speed, defaulting to 1.0 to match prior behavior. HEATSOAK_BED always bumps it back to full speed once the bed reaches target, so heat still gets spread into the chamber for the remainder of the soak.