### PR TITLE
feat(mellow-pro-x10): Add Mellow Fly Pro X10 mainboard support

### DIFF
--- a/config/mcu_definitions/main/Mellow_Fly_Pro_X10.cfg
+++ b/config/mcu_definitions/main/Mellow_Fly_Pro_X10.cfg
@@ -1,0 +1,47 @@
+[board_pins mcu_manufacturer]
+aliases:
+    # Stepper drivers (10 slots, TMC5160 over SPI or UART depending on the plugged module)
+    MCU_DRIVE0_STEP=PE7  , MCU_DRIVE0_DIR=PG11  , MCU_DRIVE0_EN=PG10  , MCU_DRIVE0_UART=PG12  , MCU_DRIVE0_DIAG=PG8  ,
+    MCU_DRIVE1_STEP=PE8  , MCU_DRIVE1_DIR=PE14  , MCU_DRIVE1_EN=PE13  , MCU_DRIVE1_UART=PE15  , MCU_DRIVE1_DIAG=PG7  ,
+    MCU_DRIVE2_STEP=PE9  , MCU_DRIVE2_DIR=PG1   , MCU_DRIVE2_EN=PG0   , MCU_DRIVE2_UART=PE12  , MCU_DRIVE2_DIAG=PG6  ,
+    MCU_DRIVE3_STEP=PE10 , MCU_DRIVE3_DIR=PF14  , MCU_DRIVE3_EN=PF13  , MCU_DRIVE3_UART=PF15  , MCU_DRIVE3_DIAG=PG5  ,
+    MCU_DRIVE4_STEP=PE11 , MCU_DRIVE4_DIR=PF11  , MCU_DRIVE4_EN=PB2   , MCU_DRIVE4_UART=PF12  , MCU_DRIVE4_DIAG=PG4  ,
+    MCU_DRIVE5_STEP=PE2  , MCU_DRIVE5_DIR=PF10  , MCU_DRIVE5_EN=PC0   , MCU_DRIVE5_UART=PF5   , MCU_DRIVE5_DIAG=PG3  ,
+    MCU_DRIVE6_STEP=PE3  , MCU_DRIVE6_DIR=PF2   , MCU_DRIVE6_EN=PF4   , MCU_DRIVE6_UART=PF1   , MCU_DRIVE6_DIAG=PG2  ,
+    MCU_DRIVE7_STEP=PE4  , MCU_DRIVE7_DIR=PC15  , MCU_DRIVE7_EN=PF0   , MCU_DRIVE7_UART=PC14  , MCU_DRIVE7_DIAG=PB1  ,
+    MCU_DRIVE8_STEP=PE1  , MCU_DRIVE8_DIR=PB7   , MCU_DRIVE8_EN=PC13  , MCU_DRIVE8_UART=PB6   , MCU_DRIVE8_DIAG=PF9  ,
+    MCU_DRIVE9_STEP=PE0  , MCU_DRIVE9_DIR=PG14  , MCU_DRIVE9_EN=PG15  , MCU_DRIVE9_UART=PG13  , MCU_DRIVE9_DIAG=PC6  ,
+
+    MCU_TMC_MOSI=PB5 , MCU_TMC_MISO=PB4 , MCU_TMC_SCK=PB3 ,
+
+    # Each MCU_IOn pin is jumper-shared with the matching drive's DIAG pin (MCU_DRIVEn_DIAG),
+    # letting a plugged jumper cap switch that slot between a physical endstop and sensorless
+    # homing without rewiring: IO0<->DRIVE0_DIAG, IO1<->DRIVE1_DIAG, ... IO6<->DRIVE6_DIAG,
+    # MCU_HV_IN<->DRIVE7_DIAG, MCU_IN7<->DRIVE8_DIAG.
+    MCU_IO0=PG8 , MCU_IO1=PG7 , MCU_IO2=PG6 , MCU_IO3=PG5 , MCU_IO4=PG4 , MCU_IO5=PG3 , MCU_IO6=PG2 ,
+    MCU_IN7=PF9 ,
+    MCU_HV_IN=PB1 ,
+
+    MCU_ADC_0=PC5 , MCU_ADC_1=PC4 , MCU_ADC_2=PA4 , MCU_ADC_3=PB0 , MCU_ADC_4=PC1 , MCU_ADC_5=PF3 ,
+
+    MCU_HEAT0=PF8 , MCU_HEAT1=PF7 , MCU_HEAT2=PF6 , MCU_HEAT3=PE6 , MCU_HEAT4=PE5 ,
+
+    MCU_BED=PC7 ,
+
+    MCU_FAN0=PA0 , MCU_FAN1=PA1 , MCU_FAN2=PA2 , MCU_FAN3=PA3 , MCU_FAN4=PA15 , MCU_FAN5=PB10 ,
+    MCU_FAN6=PB11 , MCU_FAN7=PD12 ,
+    # FAN6 and FAN7 are the two 4-wire PWM+tacho headers; their tacho lines aren't part of the
+    # public Frix-x naming contract but are broken out here for anyone wiring fan speed checks.
+    MCU_FAN6_TACHO=PD14 , MCU_FAN7_TACHO=PD15 ,
+
+    # BLTOUCH
+    MCU_SERVO=PC6 , # Pin 3
+    MCU_PROBE=PC3 , # Pin 5
+
+    # SCREEN
+    MCU_SCREEN_1=PA10 , MCU_SCREEN_2=PA9 , MCU_SCREEN_3=<GND> , MCU_SCREEN_4=<5V> ,
+
+    # Not shown on the manufacturer's pinout diagram, but used as `[neopixel TP_led]` with
+    # chain_count: 50 in their reference printer.cfg (which otherwise matched the diagram
+    # exactly for drives 0-6) - likely a toolhead/gantry LED strip pin.
+    MCU_NEOPIXEL=PA8 ,

--- a/docs/pinout.md
+++ b/docs/pinout.md
@@ -115,3 +115,4 @@ For more information on the boards and pinouts, please see directly the manufact
   - [BTT SKR Mini E3](https://github.com/bigtreetech/BIGTREETECH-SKR-mini-E3)
   - [Fysetc S6](https://github.com/FYSETC/FYSETC-S6)
   - [Fly Gemini v3](https://mellow-3d.github.io/fly-gemini_v3_pins.html)
+  - [Fly Pro X10](https://mellow.klipper.cn/en/docs/category/fly-pro-x10/)

--- a/user_templates/mcu_defaults/main/Mellow_Fly_Pro_X10.cfg
+++ b/user_templates/mcu_defaults/main/Mellow_Fly_Pro_X10.cfg
@@ -1,0 +1,50 @@
+
+#------------------------------------------#
+#### Mellow Fly Pro X10 MCU definition #####
+#------------------------------------------#
+
+[mcu]
+##--------------------------------------------------------------------
+serial: /dev/serial/by-id/change-me-to-the-correct-mcu-path
+# canbus_uuid: change-me-to-the-correct-canbus-id
+##--------------------------------------------------------------------
+
+[include config/mcu_definitions/main/Mellow_Fly_Pro_X10.cfg] # Do not remove this line
+[board_pins fly_Pro_X10_mcu]
+mcu: mcu
+aliases:
+    X_STEP=MCU_DRIVE0_STEP   , X_DIR=MCU_DRIVE0_DIR   , X_ENABLE=MCU_DRIVE0_EN   , X_TMCUART=MCU_DRIVE0_UART   ,
+    Y_STEP=MCU_DRIVE1_STEP   , Y_DIR=MCU_DRIVE1_DIR   , Y_ENABLE=MCU_DRIVE1_EN   , Y_TMCUART=MCU_DRIVE1_UART   ,
+
+    Z_STEP=MCU_DRIVE2_STEP   , Z_DIR=MCU_DRIVE2_DIR   , Z_ENABLE=MCU_DRIVE2_EN   , Z_TMCUART=MCU_DRIVE2_UART   ,
+    Z1_STEP=MCU_DRIVE3_STEP  , Z1_DIR=MCU_DRIVE3_DIR  , Z1_ENABLE=MCU_DRIVE3_EN  , Z1_TMCUART=MCU_DRIVE3_UART  ,
+    Z2_STEP=MCU_DRIVE4_STEP  , Z2_DIR=MCU_DRIVE4_DIR  , Z2_ENABLE=MCU_DRIVE4_EN  , Z2_TMCUART=MCU_DRIVE4_UART  ,
+    Z3_STEP=MCU_DRIVE5_STEP  , Z3_DIR=MCU_DRIVE5_DIR  , Z3_ENABLE=MCU_DRIVE5_EN  , Z3_TMCUART=MCU_DRIVE5_UART  ,
+
+    E_STEP=MCU_DRIVE6_STEP   , E_DIR=MCU_DRIVE6_DIR   , E_ENABLE=MCU_DRIVE6_EN   , E_TMCUART=MCU_DRIVE6_UART   ,
+
+    DRIVER_SPI_MOSI=MCU_TMC_MOSI , # Used in case of SPI drivers such as TMC2240 or TMC5160
+    DRIVER_SPI_MISO=MCU_TMC_MISO , # Used in case of SPI drivers such as TMC2240 or TMC5160
+    DRIVER_SPI_SCK=MCU_TMC_SCK  , # Used in case of SPI drivers such as TMC2240 or TMC5160
+
+    X_STOP=MCU_IO0 , Y_STOP=MCU_IO1 , Z_STOP=MCU_IO2 ,
+    PROBE_INPUT=MCU_HV_IN  ,
+    RUNOUT_SENSOR=MCU_IO3 ,
+
+    E_HEATER=MCU_HEAT0   , E_TEMPERATURE=MCU_ADC_0   ,
+    BED_HEATER=MCU_BED   , BED_TEMPERATURE=MCU_ADC_5 ,
+
+    PART_FAN=MCU_FAN0 , E_FAN=MCU_FAN1 ,
+    CONTROLLER_FAN=MCU_FAN2        ,
+    EXHAUST_FAN=MCU_FAN3           ,
+    FILTER_FAN=MCU_FAN4            ,
+    HOST_CONTROLLER_FAN=MCU_FAN5   ,
+
+    CHAMBER_TEMPERATURE=MCU_ADC_1 ,
+    ELECTRICAL_CABINET_TEMPERATURE=MCU_ADC_2 ,
+
+    LIGHT_OUTPUT=MCU_HEAT1    ,
+#    LIGHT_NEOPIXEL=  ,
+    STATUS_NEOPIXEL=MCU_NEOPIXEL , # unverified against the pinout diagram, see MCU_NEOPIXEL comment
+
+    SERVO_PIN=MCU_SERVO ,


### PR DESCRIPTION
Add board_pins definitions for the Mellow Fly Pro X10 (STM32H723, CM4-integrated mainboard, 10 TMC5160 driver slots). Pins were transcribed from the manufacturer's pinout diagram and cross-checked against their published reference Klipper config for drives 0-6, which matched exactly.

The default X/Y/Z/Z1/Z2/Z3/E wiring template only uses drives 0-6; drives 7-9 are defined in the low-level board_pins file for advanced setups.