### PR TITLE
fix(probe): Close unterminated include in bltouch_virtual.cfg

### DIFF
--- a/config/hardware/probes/bltouch_virtual.cfg
+++ b/config/hardware/probes/bltouch_virtual.cfg
@@ -17,7 +17,7 @@ gcode:
 
 # The BLTouch probe definition also includes the probe management and
 # overides directly from here
-[include ../../../macros/base/homing/homing_override.cfg
+[include ../../../macros/base/homing/homing_override.cfg]
 [include ../../../macros/base/probing/generic_probe.cfg]
 
 [bltouch]


### PR DESCRIPTION
## Summary
- Line 20 of `bltouch_virtual.cfg` was missing the closing `]` on the `homing_override.cfg` include, merging it with the following include line into a single invalid Klipper config section.
- Adds the missing bracket so the file parses like every other probe config.

Fixes #811

## Test plan
- [x] `python3 scripts/validate_probe_framework.py`
- [x] `python3 -m pytest tests/`