### PR TITLE
fix: forward force mesh to adaptive bed mesh

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -46,6 +46,7 @@ In addition, there are a few other optional parameters that are supported in Kli
   - `CHAMBER=[chamber_temperature]` to set a target heatsoak temperature during the START_PRINT sequence.
   - `MINIMAL_CHAMBER=[chamber_minimal_temperature]` to start the print as soon as the chamber reaches this minimal temperature instead of waiting for the full `CHAMBER` setpoint. `CHAMBER` is still used as the setpoint (raised to at least this value) for custom macros such as bed fans.
   - `TOTAL_LAYER=[total_layer_count]` to be able to set the PRINT_STATS_INFOS in Klipper. If you use this, you will also need to add the corresponding `SET_PRINT_STATS_INFO CURRENT_LAYER={layer_num}` to your slicer custom layer change gcode.
+  - `FORCE_MESH=1` to force a 3×3 adaptive bed mesh for very small parts.
   - `TOOLS_USED=!referenced_tools!` *(only for MMU users)* is highly recommended to check only the used tools with the HappyHare [Moonraker gcode preprocessor](https://github.com/moggieuk/Happy-Hare/blob/main/doc/gcode_preprocessing.md).
   - `CHECK_GATES=0` or `1` *(only for MMU users)* that will override the corresponding variable defined in Klippain `variables.cfg` for this specific print.
   - `SYNC_MMU_EXTRUDER=1` *(only for MMU users)* if you want to stay with the default `sync_to_extruder: 0` value of HappyHare (defined in `mmu/mmu_parameters.cfg`), but still want to use the sync for a specific print.

--- a/macros/base/start_print.cfg
+++ b/macros/base/start_print.cfg
@@ -38,6 +38,7 @@ gcode:
     {% set TOOLS_USED = params.TOOLS_USED|default("")|string %} # Check if MMU gates (used in gcode file) are availables
     {% set SYNC_MMU_EXTRUDER = params.SYNC_MMU_EXTRUDER|default(0)|int %} # set MMU gear motor and extruder synchronization during print TODO
     {% set BED_MESH_PROFILE = params.MESH|default("")|string %} # Bed mesh profile to load
+    {% set FORCE_MESH = params.FORCE_MESH|default(0)|int %} # Force adaptive mesh for small parts
     {% set ADAPTIVE_PRIMELINE = params.ADAPTIVE_PRIMELINE|default(printer['gcode_macro _USER_VARIABLES'].prime_line_adaptive_mode)|default(1)|int %} # Place an adaptive prime line near the real print zone
 
     # Set the variables to be used in all the modules based on the slicer parameters
@@ -193,7 +194,7 @@ gcode:
         {% elif action == "beacon_calib" %}
             _MODULE_CONTACT_AUTO_CALIBRATE
         {% elif action == "bedmesh" %}
-            _MODULE_BED_MESH
+            _MODULE_BED_MESH FORCE_MESH={FORCE_MESH}
         {% elif action == "primeline" %}
             _MODULE_PRIMELINE
         {% elif action == "extruder_preheating" %}
@@ -504,6 +505,7 @@ gcode:
     # ----- BED MESH -------------------------------------------
     {% set FL_SIZE = printer["gcode_macro START_PRINT"].fl_size %}
     {% set BED_MESH_PROFILE = printer["gcode_macro START_PRINT"].bed_mesh_profile %}
+    {% set FORCE_MESH = params.FORCE_MESH|default(0)|int %}
 
     {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
     {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
@@ -514,7 +516,7 @@ gcode:
             {% if verbose %}
                 RESPOND MSG="Bed mesh measurement..."
             {% endif %}
-            ADAPTIVE_BED_MESH SIZE={FL_SIZE}
+            ADAPTIVE_BED_MESH SIZE={FL_SIZE} FORCE_MESH={FORCE_MESH}
         {% else %}
             {% if verbose %}
                 RESPOND MSG="Load bed mesh profile : {BED_MESH_PROFILE}"


### PR DESCRIPTION
## Summary

- forward the slicer-provided FORCE_MESH option through START_PRINT
- normalize the parameter as integer 0/1 at the entry point
- pass it explicitly through the modular bed-mesh action
- document FORCE_MESH for START_PRINT users

## Verification

- python3 -m pytest -q
- bash tests/install_mcu_templates_test.sh
- git diff --check