### PR TITLE
fix: Restore active bed mesh after intermediate homing

### DIFF
--- a/macros/base/homing/homing_beacon_contact.cfg
+++ b/macros/base/homing/homing_beacon_contact.cfg
@@ -146,8 +146,9 @@ gcode:
 [gcode_macro _HOME_XY]
 description: Perform actions before or after homing x or y axis
 variable_saved_accel: 0
+variable_active_mesh_profile: ""
 gcode:
-    {% set bed_mesh_enabled = printer["gcode_macro _USER_VARIABLES"].bed_mesh_enabled %}
+    {% set verbose = printer["gcode_macro _USER_VARIABLES"].verbose %}
     {% set homing_travel_accel = printer['gcode_macro _USER_VARIABLES'].homing_travel_accel %}
     {% set status_leds_control_enabled = printer["gcode_macro _USER_VARIABLES"].status_leds_control_enabled|default(False) %}
     {% set probing_active = printer["gcode_macro ACTIVATE_PROBE"].is_active %}
@@ -171,7 +172,10 @@ gcode:
         SET_GCODE_VARIABLE MACRO=_HOME_XY VARIABLE=saved_accel VALUE={printer.toolhead.max_accel}
         M204 S{homing_travel_accel}
 
-        {% if bed_mesh_enabled %}
+        # Check the printer object rather than bed_mesh_enabled so a customized bed
+        # mesh setup still gets its active profile preserved across this homing sequence
+        {% if printer["configfile"].config["bed_mesh"] is defined %}
+            SET_GCODE_VARIABLE MACRO=_HOME_XY VARIABLE=active_mesh_profile VALUE='"{printer.bed_mesh.profile_name|default("")}"'
             BED_MESH_CLEAR
         {% endif %}
 
@@ -184,6 +188,15 @@ gcode:
         # Reset acceleration values to what it was before
         {% set saved_accel = printer["gcode_macro _HOME_XY"].saved_accel %}
         SET_VELOCITY_LIMIT ACCEL={saved_accel}
+
+        # Restore the mesh that was active before this homing sequence cleared it
+        {% set active_mesh_profile = printer["gcode_macro _HOME_XY"].active_mesh_profile %}
+        {% if active_mesh_profile %}
+            {% if verbose %}
+                { action_respond_info("Restoring bed mesh profile '%s' after homing" % active_mesh_profile) }
+            {% endif %}
+            BED_MESH_PROFILE LOAD="{active_mesh_profile}"
+        {% endif %}
 
         {% if status_leds_control_enabled %}
             STATUS_LEDS COLOR="ready"

--- a/macros/base/homing/homing_override.cfg
+++ b/macros/base/homing/homing_override.cfg
@@ -72,7 +72,11 @@ gcode:
     {% set saved_accel = printer.toolhead.max_accel %}
     SET_VELOCITY_LIMIT ACCEL={homing_travel_accel}
 
-    {% if bed_mesh_enabled %}
+    # Check the printer object rather than bed_mesh_enabled so a customized bed mesh
+    # setup still gets its active profile preserved across this homing sequence
+    {% set active_mesh_profile = "" %}
+    {% if printer["configfile"].config["bed_mesh"] is defined %}
+        {% set active_mesh_profile = printer.bed_mesh.profile_name|default("") %}
         BED_MESH_CLEAR
     {% endif %}
 
@@ -355,6 +359,14 @@ gcode:
 
     {% if probe_type_enabled == "dockable" or probe_type_enabled == "dockable_virtual" %}
         _CHECK_PROBE action=query
+    {% endif %}
+
+    # Restore the mesh that was active before this homing sequence cleared it
+    {% if active_mesh_profile %}
+        {% if verbose %}
+            { action_respond_info("Restoring bed mesh profile '%s' after homing" % active_mesh_profile) }
+        {% endif %}
+        BED_MESH_PROFILE LOAD="{active_mesh_profile}"
     {% endif %}
 
     # Reset acceleration values to what it was before


### PR DESCRIPTION
## Summary

Closes #219

With a virtual Z probe, `BED_MESH_CLEAR` at the top of `[homing_override]` (and the equivalent `_HOME_XY` pre/post hook for `beacon_contact`) runs on **every** `G28` call, including intermediate `G28 Z` calls issued later in `START_PRINT` (`_MODULE_Z_CALIB`, and `_MODULE_CLEAN` when `force_homing_before_brush` is enabled). If a mesh was already loaded or freshly calibrated earlier in the sequence, it gets wiped and never reloaded, so the print starts without bed mesh compensation.

`BED_MESH_CLEAR` only deactivates the mesh (`set_mesh(None)`); it never removes the profile from Klipper's in-memory profile store. So this fix captures the active profile name (`printer.bed_mesh.profile_name`) before clearing, and reloads it with `BED_MESH_PROFILE LOAD` once homing completes. This works for both explicitly saved and ad-hoc/unnamed meshes, since Klipper always assigns a profile name (defaulting to `"default"`) when calibrating.

The check for whether to attempt this looks at the printer object directly (`printer["configfile"].config["bed_mesh"] is defined`) rather than the `bed_mesh_enabled` toggle variable, so it also covers customized bed mesh setups.

- `macros/base/homing/homing_override.cfg`: covers all probe types except `beacon_contact`.
- `macros/base/homing/homing_beacon_contact.cfg`: same fix for `beacon_contact`'s separate `_HOME_XY` pre/post homing hooks, persisting the captured name across the two invocations the same way `saved_accel` already does.

## Test plan

Validated end-to-end on real hardware (Voron TAP virtual Z probe):
- [x] Homed cleanly, `BED_MESH_CALIBRATE` produced an active `"default"` profile
- [x] Intermediate `G28 Z` with a mesh active: `profile_name` unchanged before/after; log shows `Homing Z` → `Restoring bed mesh profile 'default' after homing` → mesh reloaded
- [x] Intermediate `G28 Z` with no mesh active: stays empty, no errors, klippy stays `ready`